### PR TITLE
Override methods in LinearContainer and some API changes

### DIFF
--- a/samples/BoxContainersExample/Program.cs
+++ b/samples/BoxContainersExample/Program.cs
@@ -2,7 +2,7 @@
 using CatUI.Data.Brushes;
 using CatUI.Data.Containers.LinearContainers;
 using CatUI.Data.ElementData;
-using CatUI.Elements.Containers;
+using CatUI.Elements.Containers.Linear;
 using CatUI.Elements.Shapes;
 using CatUI.Windowing.Desktop;
 

--- a/samples/CatUISample/CatUISample.UI/Pages/Layout/RowContainersExamples.cs
+++ b/samples/CatUISample/CatUISample.UI/Pages/Layout/RowContainersExamples.cs
@@ -3,7 +3,7 @@ using CatUI.Data.Containers.LinearContainers;
 using CatUI.Data.ElementData;
 using CatUI.Data.Enums;
 using CatUI.Data.Theming;
-using CatUI.Elements.Containers;
+using CatUI.Elements.Containers.Linear;
 using CatUI.Elements.Shapes;
 using CatUI.Elements.Text;
 
@@ -54,8 +54,6 @@ namespace CatUISample.UI.Pages.Layout
                     },
                     new RowContainer
                     {
-                        //TODO: this is not added to the cache, as it should've thrown DuplicateIdException
-                        Id = "Row",
                         Layout = new ElementLayout().SetFixedWidth("100%"),
                         Arrangement = new LinearArrangement(justification, 0),
                         Background = new ColorBrush(CatTheme.Colors.SurfaceContainer),

--- a/samples/CatUISample/CatUISample.UI/Pages/MainPage.cs
+++ b/samples/CatUISample/CatUISample.UI/Pages/MainPage.cs
@@ -2,7 +2,7 @@ using CatUI.Data.Brushes;
 using CatUI.Data.ElementData;
 using CatUI.Data.Enums;
 using CatUI.Data.Theming;
-using CatUI.Elements.Containers;
+using CatUI.Elements.Containers.Linear;
 using CatUI.Elements.Text;
 
 namespace CatUISample.UI.Pages

--- a/samples/CatUISample/CatUISample.UI/RootElement.cs
+++ b/samples/CatUISample/CatUISample.UI/RootElement.cs
@@ -5,7 +5,7 @@ using CatUI.Data.ElementData;
 using CatUI.Data.Navigator;
 using CatUI.Data.Theming;
 using CatUI.Elements.Buttons;
-using CatUI.Elements.Containers;
+using CatUI.Elements.Containers.Linear;
 using CatUI.Elements.Helpers.Navigation;
 using CatUI.Utils;
 using CatUISample.UI.Pages;

--- a/src/CatUI.Data/Brushes/ColorBrush.cs
+++ b/src/CatUI.Data/Brushes/ColorBrush.cs
@@ -5,7 +5,7 @@ using SkiaSharp;
 
 namespace CatUI.Data.Brushes
 {
-    public class ColorBrush : IBrush, INotifyPropertyChanged
+    public class ColorBrush : IBrush
     {
         public bool IsSkippable => Color.A == 0;
 

--- a/src/CatUI.Data/Brushes/IBrush.cs
+++ b/src/CatUI.Data/Brushes/IBrush.cs
@@ -1,8 +1,9 @@
-﻿using SkiaSharp;
+﻿using System.ComponentModel;
+using SkiaSharp;
 
 namespace CatUI.Data.Brushes
 {
-    public interface IBrush
+    public interface IBrush : INotifyPropertyChanged
     {
         public SKPaint ToSkiaPaint();
 

--- a/src/CatUI.Data/ObservableProperty.cs
+++ b/src/CatUI.Data/ObservableProperty.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace CatUI.Data
 {
@@ -9,7 +9,7 @@ namespace CatUI.Data
     /// On destruction, this object will automatically remove all the listeners of <see cref="ValueChangedEvent"/>.
     /// </summary>
     /// <typeparam name="T">The type of the contained object.</typeparam>
-    public class ObservableProperty<T> : CatObject where T : notnull
+    public class ObservableProperty<T> where T : notnull
     {
         /// <summary>
         /// Represents the actual value of the property. Setting this to a different value than the previous one will notify all
@@ -25,7 +25,18 @@ namespace CatUI.Data
                     return;
                 }
 
+                if (_value is INotifyPropertyChanged oldReactiveObject)
+                {
+                    oldReactiveObject.PropertyChanged -= OnPropertyChanged;
+                }
+
                 _value = value;
+
+                if (value is INotifyPropertyChanged newReactiveObject)
+                {
+                    newReactiveObject.PropertyChanged += OnPropertyChanged;
+                }
+
                 ValueChangedEvent?.Invoke(value);
             }
         }
@@ -42,16 +53,6 @@ namespace CatUI.Data
         ~ObservableProperty()
         {
             ValueChangedEvent = null;
-        }
-
-        /// <summary>
-        /// Not implemented because cannot guarantee that T is CatObject, therefore the duplication method for T is unknown.
-        /// </summary>
-        /// <returns></returns>
-        /// <exception cref="NotImplementedException"></exception>
-        public override CatObject Duplicate()
-        {
-            throw new NotImplementedException("Duplicating ObservableProperty is not supported.");
         }
 
         /// <summary>
@@ -127,6 +128,11 @@ namespace CatUI.Data
         private void OnChangeCall(T? newValue)
         {
             Value = newValue;
+        }
+
+        private void OnPropertyChanged(object? sender, PropertyChangedEventArgs? e)
+        {
+            ValueChangedEvent?.Invoke(_value);
         }
     }
 

--- a/src/CatUI.Elements/Buttons/Button.cs
+++ b/src/CatUI.Elements/Buttons/Button.cs
@@ -6,7 +6,7 @@ using CatUI.Data.ElementData;
 using CatUI.Data.Enums;
 using CatUI.Data.Shapes;
 using CatUI.Elements.Behaviors;
-using CatUI.Elements.Containers;
+using CatUI.Elements.Containers.Linear;
 using CatUI.Elements.Media;
 using CatUI.Elements.Shapes;
 using CatUI.Elements.Text;

--- a/src/CatUI.Elements/Containers/Linear/ColumnContainer.cs
+++ b/src/CatUI.Elements/Containers/Linear/ColumnContainer.cs
@@ -5,7 +5,7 @@ using CatUI.Data.Enums;
 using CatUI.Data.Shapes;
 using CatUI.Utils;
 
-namespace CatUI.Elements.Containers
+namespace CatUI.Elements.Containers.Linear
 {
     public class ColumnContainer : LinearContainer
     {

--- a/src/CatUI.Elements/Containers/Linear/LinearContainer.cs
+++ b/src/CatUI.Elements/Containers/Linear/LinearContainer.cs
@@ -5,9 +5,9 @@ using CatUI.Data.ElementData;
 using CatUI.Data.Enums;
 using CatUI.Data.Events.Document;
 
-namespace CatUI.Elements.Containers
+namespace CatUI.Elements.Containers.Linear
 {
-    public abstract class LinearContainer : Container
+    public abstract partial class LinearContainer : Container
     {
         /// <summary>
         /// Specifies the arrangement of the children of this container. It only refers to the axis of orientation
@@ -305,9 +305,10 @@ namespace CatUI.Elements.Containers
                                 thisAbsolutePosition,
                                 actualSpacing);
                         finalContainerDim +=
-                            ContainerOrientation == Orientation.Horizontal
+                            actualSpacing +
+                            (ContainerOrientation == Orientation.Horizontal
                                 ? finalSize.Width
-                                : finalSize.Height;
+                                : finalSize.Height);
                         finalOppositeDim =
                             Math.Max(
                                 finalOppositeDim,
@@ -382,9 +383,10 @@ namespace CatUI.Elements.Containers
                                 thisAbsolutePosition,
                                 actualSpacing);
                         finalContainerDim +=
-                            ContainerOrientation == Orientation.Horizontal
+                            actualSpacing +
+                            (ContainerOrientation == Orientation.Horizontal
                                 ? actualSize.Width
-                                : actualSize.Height;
+                                : actualSize.Height);
                         finalOppositeDim =
                             Math.Max(
                                 finalOppositeDim,

--- a/src/CatUI.Elements/Containers/Linear/RowContainer.cs
+++ b/src/CatUI.Elements/Containers/Linear/RowContainer.cs
@@ -5,7 +5,7 @@ using CatUI.Data.Enums;
 using CatUI.Data.Shapes;
 using CatUI.Utils;
 
-namespace CatUI.Elements.Containers
+namespace CatUI.Elements.Containers.Linear
 {
     public class RowContainer : LinearContainer
     {

--- a/src/CatUI.Elements/UiDocument.cs
+++ b/src/CatUI.Elements/UiDocument.cs
@@ -197,8 +197,10 @@ namespace CatUI.Elements
         #region Artificial events
 
         /// <summary>
-        /// Simulates a pointer move inside the document. This will always fire <see cref="PointerMoveEvent"/> and will
-        /// propagate it through the elements (only eligible elements will react).
+        /// Simulates a pointer move inside the document. This will always fire <see cref="PointerMoveEvent"/> on the
+        /// document and will propagate it through the elements (where only eligible elements will react).
+        /// Both <see cref="AbstractPointerEventArgs.Position"/> and <see cref="AbstractPointerEventArgs.AbsolutePosition"/>
+        /// MUST refer to the absolute position here.
         /// </summary>
         /// <remarks>
         /// This does not interact with the platform, so it's only possible to use it inside your application, not to
@@ -215,8 +217,10 @@ namespace CatUI.Elements
         }
 
         /// <summary>
-        /// Simulates a pointer entering the document. This will always fire <see cref="PointerEnterEvent"/> and will
-        /// propagate it through the elements (only eligible elements will react).
+        /// Simulates a pointer entering the document. This will always fire <see cref="PointerEnterEvent"/> on the
+        /// document and will propagate it through the elements (where only eligible elements will react).
+        /// Both <see cref="AbstractPointerEventArgs.Position"/> and <see cref="AbstractPointerEventArgs.AbsolutePosition"/>
+        /// MUST refer to the absolute position here.
         /// </summary>
         /// <remarks>
         /// This does not interact with the platform, so it's only possible to use it inside your application, not to
@@ -230,8 +234,10 @@ namespace CatUI.Elements
         }
 
         /// <summary>
-        /// Simulates a pointer exiting the document. This will always fire <see cref="PointerExitEvent"/> and will
-        /// propagate it through the elements (only eligible elements will react).
+        /// Simulates a pointer exiting the document. This will always fire <see cref="PointerExitEvent"/> on the
+        /// document and will propagate it through the elements (where only eligible elements will react).
+        /// Both <see cref="AbstractPointerEventArgs.Position"/> and <see cref="AbstractPointerEventArgs.AbsolutePosition"/>
+        /// MUST refer to the absolute position here.
         /// </summary>
         /// <remarks>
         /// This does not interact with the platform, so it's only possible to use it inside your application, not to
@@ -245,8 +251,10 @@ namespace CatUI.Elements
         }
 
         /// <summary>
-        /// Simulates a pointer press inside the document. This will always fire <see cref="PointerDownEvent"/> and will
-        /// propagate it through the elements (only eligible elements will react).
+        /// Simulates a pointer press inside the document. This will always fire <see cref="PointerDownEvent"/> on the
+        /// document and will propagate it through the elements (where only eligible elements will react).
+        /// Both <see cref="AbstractPointerEventArgs.Position"/> and <see cref="AbstractPointerEventArgs.AbsolutePosition"/>
+        /// MUST refer to the absolute position here.
         /// </summary>
         /// <remarks>
         /// This does not interact with the platform, so it's only possible to use it inside your application, not to
@@ -260,8 +268,10 @@ namespace CatUI.Elements
         }
 
         /// <summary>
-        /// Simulates a pointer release inside the document. This will always fire <see cref="PointerUpEvent"/> and will
-        /// propagate it through the elements (only eligible elements will react).
+        /// Simulates a pointer release inside the document. This will always fire <see cref="PointerUpEvent"/> on the
+        /// document and will propagate it through the elements (where only eligible elements will react).
+        /// Both <see cref="AbstractPointerEventArgs.Position"/> and <see cref="AbstractPointerEventArgs.AbsolutePosition"/>
+        /// MUST refer to the absolute position here.
         /// </summary>
         /// <remarks>
         /// This does not interact with the platform, so it's only possible to use it inside your application, not to
@@ -276,7 +286,9 @@ namespace CatUI.Elements
 
         /// <summary>
         /// Simulates a mouse button down or up inside the document. This will always fire <see cref="MouseButtonEvent"/>
-        /// and will propagate it through the elements (only eligible elements will react).
+        /// on the document and will propagate it through the elements (where only eligible elements will react).
+        /// Both <see cref="AbstractPointerEventArgs.Position"/> and <see cref="AbstractPointerEventArgs.AbsolutePosition"/>
+        /// MUST refer to the absolute position here.
         /// </summary>
         /// <remarks>
         /// This does not interact with the platform, so it's only possible to use it inside your application, not to
@@ -295,7 +307,9 @@ namespace CatUI.Elements
 
         /// <summary>
         /// Simulates a mouse wheel interaction inside the document. This will always fire <see cref="MouseWheelEvent"/>
-        /// and will propagate it through the elements (only eligible elements will react).
+        /// on the document and will propagate it through the elements (where only eligible elements will react).
+        /// Both <see cref="AbstractPointerEventArgs.Position"/> and <see cref="AbstractPointerEventArgs.AbsolutePosition"/>
+        /// MUST refer to the absolute position here.
         /// </summary>
         /// <remarks>
         /// This does not interact with the platform, so it's only possible to use it inside your application, not to

--- a/template/ProjectName.UI/RootElement.cs
+++ b/template/ProjectName.UI/RootElement.cs
@@ -2,7 +2,7 @@
 using CatUI.Data.Brushes;
 using CatUI.Data.ElementData;
 using CatUI.Data.Enums;
-using CatUI.Elements.Containers;
+using CatUI.Elements.Containers.Linear;
 using CatUI.Elements.Text;
 using CatUI.Utils;
 


### PR DESCRIPTION
- Override the input checking and drawing methods inside LinearContainer for better performance
- API change: Move LinearContainer, RowContainer and ColumnContainer to CatUI.Elements.Containers.Linear namespace
- Fix #97 and #104