### PR TITLE
Add default theme (Itania) and other API changes

### DIFF
--- a/src/CatUI.Data/CatApplication.cs
+++ b/src/CatUI.Data/CatApplication.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using CatUI.Data.Exceptions;
 using CatUI.Platform.Essentials;
 
 namespace CatUI.Data
@@ -13,15 +14,20 @@ namespace CatUI.Data
     {
         /// <summary>
         /// The global application object. Accessing this before creating the object with <see cref="NewBuilder"/>
-        /// will create a global instance with all the default parameters set, meaning it is unmodifiable after this point.
-        /// You should always create a new instance with <see cref="NewBuilder"/>, then calling
-        /// <see cref="AppBuilder.Build"/> before any CatUI-specific calls, as that will initialize this object properly.
+        /// will throw a <see cref="CatApplicationUninitializedException"/>. You should always create a new instance
+        /// with <see cref="NewBuilder"/>, then calling <see cref="AppBuilder.Build"/> before any CatUI-specific calls,
+        /// as that will initialize this object properly.
         /// </summary>
         public static CatApplication Instance
         {
             get
             {
-                _instance ??= new CatApplication();
+                if (_instance == null)
+                {
+                    throw new CatApplicationUninitializedException(
+                        "CatApplication is uninitialized. Did you forget to initialize it through CatApplicationBuilder?");
+                }
+
                 return _instance;
             }
         }
@@ -185,7 +191,7 @@ namespace CatUI.Data
                     throw new InvalidOperationException("A CatApplication has already been instantiated.");
                 }
 
-                //using Instance here is OK, as this has private access to CatApplication
+                _instance = new CatApplication();
                 Instance.AppName = _appName;
                 Instance.DebugLogLevel = _debugLogLevel;
                 Instance.ReleaseLogLevel = _releaseLogLevel;

--- a/src/CatUI.Data/Dimension.cs
+++ b/src/CatUI.Data/Dimension.cs
@@ -45,6 +45,7 @@ namespace CatUI.Data
                 Unit.Percent => "%",
                 Unit.ViewportWidth => "vw",
                 Unit.ViewportHeight => "vh",
+                Unit.Em => "em",
                 _ => "?"
             };
 
@@ -105,6 +106,9 @@ namespace CatUI.Data
                         break;
                     case "vh":
                         unit = Unit.ViewportHeight;
+                        break;
+                    case "em":
+                        unit = Unit.Em;
                         break;
                     default:
                         unitStartPos = literal.Length;
@@ -183,8 +187,14 @@ namespace CatUI.Data
         public float CalculateDimension(
             float pixelDimensionForPercent = 0,
             float contentScale = 1,
-            Size? viewportSize = null)
+            Size? viewportSize = null,
+            float rootEmSize = 16)
         {
+            if (IsUnset())
+            {
+                return 0;
+            }
+
             switch (MeasuringUnit)
             {
                 default:
@@ -198,6 +208,8 @@ namespace CatUI.Data
                     return Value * (viewportSize?.Width ?? 0) / 100f;
                 case Unit.ViewportHeight:
                     return Value * (viewportSize?.Height ?? 0) / 100f;
+                case Unit.Em:
+                    return Value * rootEmSize * contentScale;
             }
         }
 
@@ -210,6 +222,19 @@ namespace CatUI.Data
         public static float PxToDp(float px, float contentScale)
         {
             return px / contentScale;
+        }
+
+        /// <summary>
+        /// Given a pixel value, the content scale (from Document.ContentScale) and a root em size (from
+        /// Document.RootEmSize), returns the corresponding em value.
+        /// </summary>
+        /// <param name="px">The pixel value to convert.</param>
+        /// <param name="contentScale">The document content scale.</param>
+        /// <param name="rootEmSize">The document root em size.</param>
+        /// <returns>The equivalent value in em.</returns>
+        public static float PxToEm(float px, float contentScale, float rootEmSize)
+        {
+            return px / contentScale / rootEmSize;
         }
     }
 

--- a/src/CatUI.Data/Enums/SizeEnums.cs
+++ b/src/CatUI.Data/Enums/SizeEnums.cs
@@ -28,6 +28,16 @@
         /// <summary>
         /// Relative to the viewport height (in most cases, the window height). From 0 to 100.
         /// </summary>
-        ViewportHeight = 4
+        ViewportHeight = 4,
+
+        /// <summary>
+        /// Factor of the root em font size (set in UiDocument). Must be greater than 0. You should use this only for
+        /// font sizes.
+        /// </summary>
+        /// <example>
+        /// 1 em means 1 * RootEmSize, 1.5em means 1.5 * RootEmSize, so in these examples, if RootEmSize is 16 dp
+        /// (always set it in dp, not px or anything else), then you'll have 16 dp and 24 dp respectively.
+        /// </example>
+        Em = 5
     }
 }

--- a/src/CatUI.Data/Exceptions/CatApplicationExceptions.cs
+++ b/src/CatUI.Data/Exceptions/CatApplicationExceptions.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace CatUI.Data.Exceptions
+{
+    /// <summary>
+    /// Occurs when you try to use any kind of CatUI specific API before initializing <see cref="CatApplication"/>
+    /// properly.
+    /// </summary>
+    public class CatApplicationUninitializedException : Exception
+    {
+        public CatApplicationUninitializedException(string message) : base(message) { }
+
+        public CatApplicationUninitializedException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/CatUI.Elements/Containers/Scroll/HorizontalScrollBar.cs
+++ b/src/CatUI.Elements/Containers/Scroll/HorizontalScrollBar.cs
@@ -28,7 +28,7 @@ namespace CatUI.Elements.Containers.Scroll
                 })
             {
                 Layout = new ElementLayout().SetFixedWidth(20).SetFixedHeight(20),
-                Background = new ColorBrush(new Color(0x42_A5_F5))
+                Background = new ColorBrush(new Color(0x8C_8C_8C))
             };
 
         public Button RightButtonElement
@@ -47,7 +47,7 @@ namespace CatUI.Elements.Containers.Scroll
                 })
             {
                 Layout = new ElementLayout().SetFixedWidth(20).SetFixedHeight(20),
-                Background = new ColorBrush(new Color(0x42_A5_F5))
+                Background = new ColorBrush(new Color(0x8C_8C_8C))
             };
 
         public HorizontalScrollBar()

--- a/src/CatUI.Elements/Containers/Scroll/ScrollBarBase.cs
+++ b/src/CatUI.Elements/Containers/Scroll/ScrollBarBase.cs
@@ -179,6 +179,8 @@ namespace CatUI.Elements.Containers.Scroll
                 {
                     InternalContent[idx] = value;
                 }
+
+                _minusButtonElement.ClickEvent += OnButtonMinusClick;
             }
         }
 
@@ -186,11 +188,11 @@ namespace CatUI.Elements.Containers.Scroll
 
         protected Button PlusButtonElement
         {
-            get => _plusButton!;
+            get => _plusButtonElement!;
             set
             {
-                int idx = _plusButton?.IndexInParent ?? -1;
-                _plusButton = value;
+                int idx = _plusButtonElement?.IndexInParent ?? -1;
+                _plusButtonElement = value;
 
                 //InternalContent will be null in constructor
                 // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
@@ -198,10 +200,12 @@ namespace CatUI.Elements.Containers.Scroll
                 {
                     InternalContent[idx] = value;
                 }
+
+                _plusButtonElement.ClickEvent += OnButtonPlusClick;
             }
         }
 
-        private Button? _plusButton;
+        private Button? _plusButtonElement;
 
         /// <summary>
         /// Represents the place where the scroll thumb is free to move. This usually occupies the entire width or height
@@ -222,6 +226,10 @@ namespace CatUI.Elements.Containers.Scroll
                 {
                     InternalContent[idx] = value;
                 }
+
+                _internalScrollTrackElement.PointerUpEvent += OnScrollTrackPointerUp;
+                _internalScrollTrackElement.PointerDownEvent += OnScrollTrackPointerDown;
+                _internalScrollTrackElement.PointerMoveEvent += OnScrollTrackPointerMove;
             }
         }
 
@@ -244,7 +252,7 @@ namespace CatUI.Elements.Containers.Scroll
         }
 
         private Element _internalThumbElement =
-            new RectangleElement { FillBrush = new ColorBrush(new Color(0x64_B5_F6)) };
+            new RectangleElement { FillBrush = new ColorBrush(new Color(0x8C_8C_8C)) };
 
         /// <summary>
         /// Contains the minus/plus buttons (if present) and the scroller track. You can add elements to this
@@ -290,12 +298,6 @@ namespace CatUI.Elements.Containers.Scroll
                 InternalScrollTrackElement,
                 plusButtonElement
             ];
-
-            InternalScrollTrackElement.PointerUpEvent += OnScrollTrackPointerUp;
-            InternalScrollTrackElement.PointerDownEvent += OnScrollTrackPointerDown;
-            InternalScrollTrackElement.PointerMoveEvent += OnScrollTrackPointerMove;
-            MinusButtonElement.ClickEvent += OnButtonMinusClick;
-            PlusButtonElement.ClickEvent += OnButtonPlusClick;
 
             ShouldDisplayButtonsProperty.ValueChangedEvent += SetShouldDisplayButtons;
             RepositionBehaviorProperty.ValueChangedEvent += SetRepositionBehavior;

--- a/src/CatUI.Elements/Containers/Scroll/VerticalScrollBar.cs
+++ b/src/CatUI.Elements/Containers/Scroll/VerticalScrollBar.cs
@@ -28,7 +28,7 @@ namespace CatUI.Elements.Containers.Scroll
                 })
             {
                 Layout = new ElementLayout().SetFixedWidth(20).SetFixedHeight(20),
-                Background = new ColorBrush(new Color(0x42_A5_F5))
+                Background = new ColorBrush(new Color(0x8C_8C_8C))
             };
 
         public Button DownButtonElement
@@ -47,7 +47,7 @@ namespace CatUI.Elements.Containers.Scroll
                 })
             {
                 Layout = new ElementLayout().SetFixedWidth(20).SetFixedHeight(20),
-                Background = new ColorBrush(new Color(0x42_A5_F5))
+                Background = new ColorBrush(new Color(0x8C_8C_8C))
             };
 
         public VerticalScrollBar()

--- a/src/CatUI.Elements/Element.cs
+++ b/src/CatUI.Elements/Element.cs
@@ -588,6 +588,9 @@ namespace CatUI.Elements
             LayoutProperty.ValueChangedEvent += SetLayout;
 
             ThemeOverrideProperty.ValueChangedEvent += SetThemeOverride;
+            StyleClassProperty.ValueChangedEvent += SetStyleClass;
+            BaseThemingCountProperty.ValueChangedEvent += SetBaseThemingCount;
+            IgnoreGlobalThemingProperty.ValueChangedEvent += SetIgnoreGlobalTheming;
 
             Children.ItemInsertedEvent += OnChildInserted;
             Children.ItemRemovedEvent += OnChildRemoved;
@@ -818,6 +821,7 @@ namespace CatUI.Elements
             if ((ClipType & ClipApplicability.Drawing) != 0)
             {
                 restoreCount = Document.Renderer.SaveCanvasState();
+                //TODO: use ClipPath for actual clipping
                 Document.Renderer.SetClipRect(Bounds);
             }
 
@@ -1036,6 +1040,8 @@ namespace CatUI.Elements
 
                         return dimension.Value * Document.ViewportSize.Height / 100f;
                     }
+                case Unit.Em:
+                    return dimension.Value * (Document?.ContentScale ?? 1f) * (Document?.RootEmSize ?? 16f);
             }
         }
 

--- a/src/CatUI.Elements/ElementThemingPartial.cs
+++ b/src/CatUI.Elements/ElementThemingPartial.cs
@@ -49,10 +49,63 @@ namespace CatUI.Elements
 
         public ObservableProperty<string> StyleClassProperty { get; } = new("");
 
-        private void SetStyleClass(string value)
+        private void SetStyleClass(string? value)
         {
+            value ??= "";
             _styleClass = value;
             ApplyClassTheme(value, false);
+        }
+
+        /// <summary>
+        /// The number of times you want the element to go to its base type and apply the applicable theme for that type.
+        /// A value lower than 0 will apply every theme until reaching Element; 0 means only the current type will get
+        /// considered, ignoring base types. The default value is -1.
+        /// </summary>
+        /// <example>
+        /// For a TextBlock, a value of -1 means that the themes for Element, TextElement and TextBlock will be applied
+        /// in this order. A value of 0 means that only the Theme for TextBlock will be applied, while a value of 1
+        /// means that the themes for TextElement and TextBlock will be applied in this order.
+        /// </example>
+        public int BaseThemingCount
+        {
+            get => _baseThemingCount;
+            set
+            {
+                SetBaseThemingCount(value);
+                BaseThemingCountProperty.Value = value;
+            }
+        }
+
+        private int _baseThemingCount = -1;
+        public ObservableProperty<int> BaseThemingCountProperty { get; } = new(-1);
+
+        private void SetBaseThemingCount(int value)
+        {
+            _baseThemingCount = value;
+            ApplyElementTypeTheme();
+        }
+
+        /// <summary>
+        /// If set to true, the element will ignore any theme overrides from the ascendants and instead only uses the
+        /// theme overrides of itself.
+        /// </summary>
+        public bool IgnoreGlobalTheming
+        {
+            get => _ignoreGlobalTheming;
+            set
+            {
+                SetIgnoreGlobalTheming(value);
+                IgnoreGlobalThemingProperty.Value = value;
+            }
+        }
+
+        private bool _ignoreGlobalTheming;
+        public ObservableProperty<bool> IgnoreGlobalThemingProperty { get; } = new(false);
+
+        private void SetIgnoreGlobalTheming(bool value)
+        {
+            _ignoreGlobalTheming = value;
+            ApplyElementTypeTheme();
         }
 
         /// <summary>
@@ -90,25 +143,28 @@ namespace CatUI.Elements
             }
 
             //if the type is not set OR if it's the matching type
-            if (affectedType == null || GetType() == affectedType)
+            if (affectedType == null || IsMatchingType(affectedType))
             {
                 List<int> indices = new(10);
                 Element currentElement = this;
 
-                while (currentElement._parent != null)
+                if (!IgnoreGlobalTheming)
                 {
-                    indices.Add(currentElement.IndexInParent);
-                    currentElement = currentElement._parent;
-                }
+                    while (currentElement._parent != null)
+                    {
+                        indices.Add(currentElement.IndexInParent);
+                        currentElement = currentElement._parent;
+                    }
 
-                for (int i = indices.Count - 1; i >= 0; i--)
-                {
-                    currentElement.ThemeOverride?.GetElementTypeDefinition(GetType())?.InvokeOnThemeChanged(this);
-                    currentElement = currentElement.Children[indices[i]];
+                    for (int i = indices.Count - 1; i >= 0; i--)
+                    {
+                        ApplyBaseThemingFromElement(currentElement);
+                        currentElement = currentElement.Children[indices[i]];
+                    }
                 }
 
                 //check self override
-                currentElement.ThemeOverride?.GetElementTypeDefinition(GetType())?.InvokeOnThemeChanged(this);
+                ApplyBaseThemingFromElement(currentElement);
             }
 
             if (!recursive)
@@ -119,6 +175,62 @@ namespace CatUI.Elements
             foreach (Element child in Children)
             {
                 child.ApplyElementTypeTheme();
+            }
+        }
+
+        private bool IsMatchingType(Type affectedType)
+        {
+            if (BaseThemingCount == 0)
+            {
+                return GetType() == affectedType;
+            }
+
+            Type? currentType = GetType();
+            while (currentType != affectedType)
+            {
+                currentType = currentType.BaseType;
+                //reached Object
+                if (currentType == null)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private void ApplyBaseThemingFromElement(Element currentElement)
+        {
+            List<Type> baseClasses = [];
+
+            if (BaseThemingCount != 0)
+            {
+                int baseThemingCount = BaseThemingCount < 0 ? int.MaxValue : BaseThemingCount;
+                int i = 0;
+                Type? baseType = GetType();
+                while (i < baseThemingCount && baseType != null)
+                {
+                    baseClasses.Add(baseType);
+                    if (baseType == typeof(Element))
+                    {
+                        break;
+                    }
+
+                    baseType = baseType.BaseType;
+                    i++;
+                }
+            }
+            else
+            {
+                baseClasses.Add(GetType());
+            }
+
+            for (int i = baseClasses.Count - 1; i >= 0; i--)
+            {
+                currentElement
+                    .ThemeOverride
+                    ?.GetElementTypeDefinition(baseClasses[i])
+                    ?.InvokeOnThemeChanged(this);
             }
         }
 
@@ -134,16 +246,19 @@ namespace CatUI.Elements
                 List<int> indices = new(10);
                 Element currentElement = this;
 
-                while (currentElement._parent != null)
+                if (!IgnoreGlobalTheming)
                 {
-                    indices.Add(currentElement.IndexInParent);
-                    currentElement = currentElement._parent;
-                }
+                    while (currentElement._parent != null)
+                    {
+                        indices.Add(currentElement.IndexInParent);
+                        currentElement = currentElement._parent;
+                    }
 
-                for (int i = indices.Count - 1; i >= 0; i--)
-                {
-                    currentElement.ThemeOverride?.GetClassDefinition(affectedClass)?.InvokeOnThemeChanged(this);
-                    currentElement = currentElement.Children[indices[i]];
+                    for (int i = indices.Count - 1; i >= 0; i--)
+                    {
+                        currentElement.ThemeOverride?.GetClassDefinition(affectedClass)?.InvokeOnThemeChanged(this);
+                        currentElement = currentElement.Children[indices[i]];
+                    }
                 }
 
                 //check self override

--- a/src/CatUI.Elements/Itania/ItaniaTheme.cs
+++ b/src/CatUI.Elements/Itania/ItaniaTheme.cs
@@ -1,0 +1,58 @@
+using CatUI.Data;
+using CatUI.Data.Brushes;
+using CatUI.Data.ElementData;
+using CatUI.Data.Shapes;
+using CatUI.Data.Theming;
+using CatUI.Elements.Buttons;
+using CatUI.Elements.Containers.Scroll;
+using CatUI.Elements.Text;
+
+namespace CatUI.Elements.Itania
+{
+    public static class ItaniaTheme
+    {
+        public static Theme BuildFinalTheme()
+        {
+            Theme theme = new();
+
+            //text
+            theme.AddOrUpdateElementTypeDefinition(
+                typeof(TextElement),
+                new ThemeDefinition(el => ((TextElement)el).FontSize = "1em"));
+
+            theme.AddOrUpdateElementTypeDefinition(
+                typeof(TextBlock),
+                new ThemeDefinition(el => ((TextBlock)el).TextBrush = new ColorBrush(CatTheme.Colors.OnSurface)));
+
+            //scroll
+            theme.AddOrUpdateElementTypeDefinition(
+                typeof(ScrollContainer),
+                new ThemeDefinition(el =>
+                {
+                    var container = (ScrollContainer)el;
+                    container.InternalHorizontalScrollBar.Layout?.SetFixedHeight(12);
+                    container.InternalHorizontalScrollBar.ShouldDisplayButtons = false;
+                    container.InternalHorizontalScrollBar.ClipPath =
+                        new RoundedRectangleClipShape((Dimension)"50%");
+
+                    container.InternalVerticalScrollBar.Layout?.SetFixedWidth(12);
+                    container.InternalVerticalScrollBar.ShouldDisplayButtons = false;
+                    container.InternalVerticalScrollBar.ClipPath =
+                        new RoundedRectangleClipShape((Dimension)"50%");
+                }));
+
+            //button
+            theme.AddOrUpdateElementTypeDefinition(
+                typeof(Button),
+                new ThemeDefinition(el =>
+                {
+                    var btn = (Button)el;
+                    btn.Spacing = 10;
+                    btn.Padding = new EdgeInset(5, 7);
+                    btn.ClipPath = new RoundedRectangleClipShape(8);
+                    btn.Background = new ColorBrush(CatTheme.Colors.Primary);
+                }));
+            return theme;
+        }
+    }
+}

--- a/src/CatUI.Elements/Itania/README.md
+++ b/src/CatUI.Elements/Itania/README.md
@@ -1,0 +1,1 @@
+The name was picked randomly from [here](https://letsmakeagame.net/planet-name-ideas/).

--- a/src/CatUI.Elements/UiDocument.cs
+++ b/src/CatUI.Elements/UiDocument.cs
@@ -166,6 +166,23 @@ namespace CatUI.Elements
 
         private float _contentScale = 1f;
 
+        /// <summary>
+        /// The root em font size. This is generally used only for fonts. Every dimension that uses em as a measuring
+        /// unit will have the value multiplied with this value. Always consider this in dp (all calculations will take
+        /// <see cref="ContentScale"/> into account). The default value is 16.
+        /// </summary>
+        public float RootEmSize
+        {
+            get => _rootEmSize;
+            set
+            {
+                _rootEmSize = value;
+                Root?.MarkLayoutDirty();
+            }
+        }
+
+        private float _rootEmSize = 16f;
+
         #region App lifecycle
 
         /// <summary>


### PR DESCRIPTION
- `CatApplication` now throws an exception when accessing it before initialization
- Default scroll bars colors were changed to a neutral grey color
- Add em as dimension for fonts and root em on the `UiDocument`
- Elements can now get themes from derived types as well (the intended behavior), as well as ignoring the global themes for more control over styling