### PR TITLE
Multiple fixes

### DIFF
--- a/samples/CatUISample/CatUISample.UI/Pages/Layout/RowContainerExamples.cs
+++ b/samples/CatUISample/CatUISample.UI/Pages/Layout/RowContainerExamples.cs
@@ -15,11 +15,6 @@ namespace CatUISample.UI.Pages.Layout
         {
             Layout = new ElementLayout().SetFixedWidth("100%");
             Arrangement = LinearArrangement.SpacedBy(20);
-        }
-
-        protected override void EnterDocument(object sender)
-        {
-            base.EnterDocument(sender);
 
             Children =
             [

--- a/samples/CatUISample/CatUISample.UI/Pages/Layout/ScrollContainerExamples.cs
+++ b/samples/CatUISample/CatUISample.UI/Pages/Layout/ScrollContainerExamples.cs
@@ -17,11 +17,6 @@ namespace CatUISample.UI.Pages.Layout
         {
             Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%");
             Arrangement = LinearArrangement.SpacedBy(20);
-        }
-
-        protected override void EnterDocument(object sender)
-        {
-            base.EnterDocument(sender);
 
             Children =
             [

--- a/samples/CatUISample/CatUISample.UI/Pages/UiElements/ButtonsExample.cs
+++ b/samples/CatUISample/CatUISample.UI/Pages/UiElements/ButtonsExample.cs
@@ -1,0 +1,57 @@
+using CatUI.Data.Brushes;
+using CatUI.Data.ElementData;
+using CatUI.Data.Enums;
+using CatUI.Data.Theming;
+using CatUI.Elements.Buttons;
+using CatUI.Elements.Containers.Linear;
+using CatUI.Elements.Containers.Scroll;
+using CatUI.Elements.Text;
+
+namespace CatUISample.UI.Pages.UiElements
+{
+    public class ButtonsExample : ScrollContainer
+    {
+        public ButtonsExample()
+        {
+            Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%");
+
+            Content = new ColumnContainer
+            {
+                Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%"),
+                Children =
+                [
+                    new TextBlock("Buttons examples", TextAlignmentType.Center)
+                    {
+                        Layout = new ElementLayout().SetMinMaxWidth(0, "100%", true),
+                        FontSize = 32,
+                        TextBrush = new ColorBrush(CatTheme.Colors.OnSurface)
+                    },
+                    new CheckBox(
+                        CheckBox.CheckBoxState.Indeterminate,
+                        "Checkbox 1",
+                        16,
+                        new ColorBrush(CatTheme.Colors.OnSurface))
+                    {
+                        Layout = new ElementLayout().SetMinMaxWidth(100, "100%", true).SetFixedHeight(20)
+                    },
+                    new RadioButton(
+                        true,
+                        "Radio button 1",
+                        16,
+                        new ColorBrush(CatTheme.Colors.OnSurface))
+                    {
+                        Layout = new ElementLayout().SetMinMaxWidth(100, "100%", true).SetFixedHeight(20)
+                    },
+                    new SwitchButton(
+                        true,
+                        "Switch button 1",
+                        16,
+                        new ColorBrush(CatTheme.Colors.OnSurface))
+                    {
+                        Layout = new ElementLayout().SetMinMaxWidth(100, "100%", true).SetFixedHeight(20)
+                    }
+                ]
+            };
+        }
+    }
+}

--- a/samples/CatUISample/CatUISample.UI/RootElement.cs
+++ b/samples/CatUISample/CatUISample.UI/RootElement.cs
@@ -10,6 +10,7 @@ using CatUI.Elements.Helpers.Navigation;
 using CatUI.Utils;
 using CatUISample.UI.Pages;
 using CatUISample.UI.Pages.Layout;
+using CatUISample.UI.Pages.UiElements;
 using CatUISample.UI.Theming;
 
 namespace CatUISample.UI
@@ -30,7 +31,8 @@ namespace CatUISample.UI
                     {
                         { "/", _ => new NavRoute(new MainPage()) },
                         { "/Layout/RowContainer", _ => new NavRoute(new RowContainerExamples()) },
-                        { "/Layout/ScrollContainer", _ => new NavRoute(new ScrollContainerExamples()) }
+                        { "/Layout/ScrollContainer", _ => new NavRoute(new ScrollContainerExamples()) },
+                        { "/UiElements/Buttons", _ => new NavRoute(new ButtonsExample()) }
                     },
                     "/")
                 {

--- a/samples/CatUISample/CatUISample.UI/Sidebar.cs
+++ b/samples/CatUISample/CatUISample.UI/Sidebar.cs
@@ -13,25 +13,19 @@ namespace CatUISample.UI
 {
     public class Sidebar : ColumnContainer
     {
-        private readonly ObjectRef<Navigator> _navigatorRef;
-
         private readonly List<(string, string)> _entries =
         [
             ("Main page", "/"),
             ("Layout - RowContainer", "/Layout/RowContainer"),
-            ("Layout - ScrollContainer", "/Layout/ScrollContainer")
+            ("Layout - ScrollContainer", "/Layout/ScrollContainer"),
+            ("UI Elements - Buttons", "/UiElements/Buttons")
         ];
 
         public Sidebar(ObjectRef<Navigator> navigatorRef)
         {
-            _navigatorRef = navigatorRef;
-
             Layout = new ElementLayout().SetFixedWidth(250).SetFixedHeight("100%");
             Background = new ColorBrush(CatTheme.Colors.SurfaceContainer);
-        }
 
-        protected override void EnterDocument(object sender)
-        {
             foreach ((string, string) entry in _entries)
             {
                 Children.Add(
@@ -39,7 +33,7 @@ namespace CatUISample.UI
                     {
                         Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight(40),
                         StyleClass = "MenuButtons",
-                        OnClick = (_, _) => _navigatorRef.Value?.Navigate(entry.Item2)
+                        OnClick = (_, _) => navigatorRef.Value?.Navigate(entry.Item2)
                     });
                 Children.Add(new HorizontalDivider(1, new ColorBrush(Color.Default)));
             }

--- a/src/CatUI.Elements/Behaviors/IToggleable.cs
+++ b/src/CatUI.Elements/Behaviors/IToggleable.cs
@@ -1,0 +1,11 @@
+namespace CatUI.Elements.Behaviors
+{
+    public interface IToggleable
+    {
+        /// <summary>
+        /// Available for elements that can be toggled, like checkboxes, switches, radio buttons, etc. It means that
+        /// the element is currently active/on/selected.
+        /// </summary>
+        public const string STATE_ACTIVE = "active";
+    }
+}

--- a/src/CatUI.Elements/Buttons/BaseButton.cs
+++ b/src/CatUI.Elements/Buttons/BaseButton.cs
@@ -10,6 +10,8 @@ namespace CatUI.Elements.Buttons
 {
     public class BaseButton : Element, IClickable
     {
+        public const string STATE_DISABLED = "disabled";
+
         /// <inheritdoc cref="Element.Ref"/>
         public new ObjectRef<BaseButton>? Ref
         {

--- a/src/CatUI.Elements/Buttons/CheckBox.cs
+++ b/src/CatUI.Elements/Buttons/CheckBox.cs
@@ -1,0 +1,372 @@
+using CatUI.Data;
+using CatUI.Data.Brushes;
+using CatUI.Data.Containers;
+using CatUI.Data.Containers.LinearContainers;
+using CatUI.Data.ElementData;
+using CatUI.Data.Enums;
+using CatUI.Data.Events.Input.Gestures;
+using CatUI.Data.Shapes;
+using CatUI.Elements.Behaviors;
+using CatUI.Elements.Containers.Linear;
+using CatUI.Elements.Shapes;
+using CatUI.Elements.Text;
+using CatUI.Utils;
+
+namespace CatUI.Elements.Buttons
+{
+    public class CheckBox : BaseButton, IToggleable
+    {
+        /// <summary>
+        /// The checkbox is in this state when <see cref="Value"/> is <see cref="CheckBoxState.Indeterminate"/>.
+        /// </summary>
+        public const string STATE_CHECKED_INDETERMINATE = "checked-indeterminate";
+
+        /// <inheritdoc cref="Element.Ref"/>
+        public new ObjectRef<CheckBox>? Ref
+        {
+            get => _ref;
+            set
+            {
+                _ref = value;
+                if (_ref != null)
+                {
+                    _ref.Value = this;
+                }
+            }
+        }
+
+        private ObjectRef<CheckBox>? _ref;
+
+        public CheckBoxState Value
+        {
+            get => _value;
+            set => ValueProperty.Value = value;
+        }
+
+        private CheckBoxState _value = CheckBoxState.Unchecked;
+
+        public ObservableProperty<CheckBoxState> ValueProperty { get; } = new(CheckBoxState.Unchecked);
+
+        private void SetValue(CheckBoxState value)
+        {
+            _value = value;
+            SetLocalValue(nameof(Value), value);
+            MarkLayoutDirty();
+        }
+
+        /// <summary>
+        /// Represents the spacing between <see cref="IndicatorElement"/> and <see cref="TextElement"/>.
+        /// </summary>
+        public Dimension Spacing
+        {
+            get => _spacing;
+            set => SpacingProperty.Value = value;
+        }
+
+        private Dimension _spacing = new();
+        public ObservableProperty<Dimension> SpacingProperty { get; } = new(new Dimension());
+
+        private void SetSpacing(Dimension value)
+        {
+            _spacing = value;
+            SetLocalValue(nameof(Spacing), value);
+            InternalRowContainer.Arrangement.Spacing = value;
+        }
+
+        /// <summary>
+        /// Represents the horizontal arrangement of the content. A value other than <see cref="LinearArrangement.JustificationType.Start"/>,
+        /// <see cref="LinearArrangement.JustificationType.Center"/> or <see cref="LinearArrangement.JustificationType.End"/>
+        /// will make <see cref="Spacing"/> irrelevant. By default, this is <see cref="LinearArrangement.JustificationType.Center"/>.
+        /// </summary>
+        public LinearArrangement.JustificationType HorizontalArrangement
+        {
+            get => _horizontalArrangement;
+            set => HorizontalArrangementProperty.Value = value;
+        }
+
+        private LinearArrangement.JustificationType _horizontalArrangement = LinearArrangement.JustificationType.Center;
+
+        public ObservableProperty<LinearArrangement.JustificationType> HorizontalArrangementProperty
+        {
+            get;
+        } = new(LinearArrangement.JustificationType.Center);
+
+        private void SetHorizontalArrangement(LinearArrangement.JustificationType value)
+        {
+            _horizontalArrangement = value;
+            SetLocalValue(nameof(HorizontalArrangement), value);
+            InternalRowContainer.Arrangement.ContentJustification = value;
+        }
+
+        /// <summary>
+        /// Represents the vertical alignment of the content. By default, this is <see cref="VerticalAlignmentType.Center"/>.
+        /// </summary>
+        public VerticalAlignmentType VerticalAlignment
+        {
+            get => _verticalAlignment;
+            set => VerticalAlignmentProperty.Value = value;
+        }
+
+        private VerticalAlignmentType _verticalAlignment = VerticalAlignmentType.Center;
+
+        public ObservableProperty<VerticalAlignmentType> VerticalAlignmentProperty { get; }
+            = new(VerticalAlignmentType.Center);
+
+        private void SetVerticalAlignment(VerticalAlignmentType value)
+        {
+            _verticalAlignment = value;
+            SetLocalValue(nameof(VerticalAlignment), value);
+            InternalRowContainer.VerticalAlignment = value;
+        }
+
+        /// <summary>
+        /// Represents the text content of the checkbox. Contrary to the name, this can be any kind of element, but
+        /// it's much more common for it to be a <see cref="TextBlock"/>.
+        /// </summary>
+        /// <remarks>
+        /// In order to see when this is modified, assuming you don't interfere with <see cref="InternalRowContainer"/>'s
+        /// children, you can listen to <see cref="ObservableList{T}"/> events on <see cref="Element.Children"/> on
+        /// <see cref="InternalRowContainer"/>.
+        /// </remarks>
+        public Element? TextElement
+        {
+            get => _textElement;
+            set
+            {
+                if (_textElement == null)
+                {
+                    _textElement = value;
+                    if (value != null)
+                    {
+                        InternalRowContainer.Children.Add(value);
+                    }
+
+                    return;
+                }
+
+                if (value == null)
+                {
+                    InternalRowContainer.Children.Remove(_textElement);
+                    _textElement = null;
+                    return;
+                }
+
+                _textElement = value;
+                InternalRowContainer.Children[1] = value;
+            }
+        }
+
+        private Element? _textElement;
+
+        /// <summary>
+        /// The actual visual indicator element (commonly a box with a check mark inside it). This cannot be null.
+        /// It always has to be present in the hierarchy.
+        /// </summary>
+        public TriStateCheckBoxIndicator IndicatorElement
+        {
+            get => _indicatorElement;
+            set
+            {
+                _indicatorElement = value;
+                InternalRowContainer.Children[0] = value;
+                //bind the indicator to the checkbox value
+                value.ValueProperty.BindBidirectional(ValueProperty);
+            }
+        }
+
+        private TriStateCheckBoxIndicator _indicatorElement = null!;
+
+        /// <summary>
+        /// Gives direct access to the button's <see cref="RowContainer"/>, which holds <see cref="TextElement"/> and
+        /// <see cref="IndicatorElement"/>. You should generally not modify this and certainly not remove it from the document,
+        /// but you have access to it just in case you need it.
+        /// </summary>
+        /// <remarks>
+        /// Modifying properties here directly will not reflect in some properties of the CheckBox like
+        /// <see cref="HorizontalArrangement"/>, that's why you should always use the CheckBox properties instead of
+        /// manually modifying this RowContainer where possible.
+        /// </remarks>
+        public RowContainer InternalRowContainer { get; }
+
+        private readonly TriStateCheckBoxIndicator _defaultIndicatorElement =
+            new(
+                CheckBoxState.Unchecked,
+                new RectangleElement(outlineBrush: new ColorBrush(new Color(0)))
+                {
+                    StyleClass = "CheckBox::Indicator::Checked::Outer",
+                    Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%"),
+                    OutlineParameters = new OutlineParams(2f),
+                    Children =
+                    [
+                        new RectangleElement(new ColorBrush(new Color(0x00_80_ff)))
+                        {
+                            StyleClass = "CheckBox::Indicator::Checked::Inner",
+                            Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%"),
+                            Children =
+                            [
+                                new GeometricPathElement(
+                                    //from CatUI/IndirectAssets/checkmark.svg
+                                    "m 9.118746,16.621968 c -0.892928,0.892928 -2.341566,0.892713 -3.2342794,0 C 4.2141044,14.951606 2.5437422,13.281244 0.87338,11.610881 c -0.8927129,-0.892713 -0.8927129,-2.341136 0,-3.2338485 0.892713,-0.8927129 2.3412869,-0.892864 3.2342797,0 0.9952072,0.9950635 1.9904144,1.9901275 2.9856213,2.9851905 0.225188,0.225156 0.591694,0.225387 0.817082,0 2.69473,-2.6947302 5.38946,-5.3894605 8.084191,-8.0841909 0.892712,-0.8927129 2.341351,-0.8929284 3.234279,0 0.428796,0.4287953 0.669697,1.0105778 0.669697,1.6169244 0,0.6063467 -0.240901,1.1881292 -0.669697,1.6169244 C 15.858804,9.88191 12.488775,13.251939 9.118746,16.621968 Z",
+                                    new ColorBrush(new Color(0xff_ff_ff)))
+                                {
+                                    StyleClass = "CheckBox::Indicator::Checked::Graphic",
+                                    Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%")
+                                }
+                            ]
+                        }
+                    ]
+                },
+                new RectangleElement(outlineBrush: new ColorBrush(new Color(0)))
+                {
+                    StyleClass = "CheckBox::Indicator::Unchecked::Outer",
+                    Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%"),
+                    OutlineParameters = new OutlineParams(2f)
+                },
+                new RectangleElement(outlineBrush: new ColorBrush(new Color(0)))
+                {
+                    Id = "Element1",
+                    StyleClass = "CheckBox::Indicator::Indeterminate::Outer",
+                    Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%"),
+                    OutlineParameters = new OutlineParams(2f),
+                    Children =
+                    [
+                        new RectangleElement(new ColorBrush(new Color(0x00_80_ff)))
+                        {
+                            StyleClass = "CheckBox::Indicator::Indeterminate::Inner",
+                            Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%"),
+                            Children =
+                            [
+                                new GeometricPathElement(
+                                    //from CatUI/IndirectAssets/radio-button.svg
+                                    "m 5,7 h 10 c 1.662,0 3,1.338 3,3 0,1.662 -1.338,3 -3,3 H 5 C 3.338,13 2,11.662 2,10 2,8.338 3.338,7 5,7 Z",
+                                    new ColorBrush(new Color(0xff_ff_ff)))
+                                {
+                                    StyleClass = "CheckBox::Indicator::Indeterminate::Graphic",
+                                    Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%")
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ) { Layout = new ElementLayout().SetFixedWidth(20).SetFixedHeight(20) };
+
+        /// <summary>
+        /// The base constructor. Will create a new checkbox given an Element as <see cref="TextElement"/> and
+        /// a generic Element as the <see cref="IndicatorElement"/>. If indicatorElement is not given, it will be a
+        /// default element.
+        /// </summary>
+        /// <param name="initialValue"></param>
+        /// <param name="textElement">The value of <see cref="TextElement"/>.</param>
+        /// <param name="indicatorElement">
+        /// The value of <see cref="IndicatorElement"/>, will be a default element if omitted.
+        /// </param>
+        public CheckBox(
+            CheckBoxState initialValue,
+            Element textElement,
+            TriStateCheckBoxIndicator? indicatorElement = null)
+        {
+            OnClick += PrivateOnClick;
+
+            ValueProperty.ValueChangedEvent += SetValue;
+            SpacingProperty.ValueChangedEvent += SetSpacing;
+            HorizontalArrangementProperty.ValueChangedEvent += SetHorizontalArrangement;
+            VerticalAlignmentProperty.ValueChangedEvent += SetVerticalAlignment;
+
+            InternalRowContainer = new RowContainer
+            {
+                Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%"),
+                Arrangement = new LinearArrangement(LinearArrangement.JustificationType.Center, 0),
+                VerticalAlignment = VerticalAlignmentType.Center,
+                //we need to have at least one child, as IndicatorElement will access index 0 (this will be replaced
+                //when IndicatorElement are set, immediately in this constructor)
+                Children = [new Element()]
+            };
+
+            InternalRowContainer.VerticalAlignmentProperty.BindBidirectional(VerticalAlignmentProperty);
+            Children.Add(InternalRowContainer);
+
+            indicatorElement ??= _defaultIndicatorElement;
+            IndicatorElement = indicatorElement;
+
+            TextElement = textElement;
+            Value = initialValue;
+        }
+
+        /// <summary>
+        /// Creates a new checkbox with <see cref="TextElement"/> as a new <see cref="TextBlock"/> with the given
+        /// properties.
+        /// </summary>
+        /// <param name="initialValue">The initial value of the checkbox.</param>
+        /// <param name="text">
+        /// The text that a <see cref="TextBlock"/> will have when set as the value of <see cref="TextElement"/>.
+        /// </param>
+        /// <param name="fontSize">The value of <see cref="Text.TextElement.FontSize"/>.</param>
+        /// <param name="textBrush">The value of <see cref="TextBlock.TextBrush"/>.</param>
+        public CheckBox(
+            CheckBoxState initialValue,
+            string text,
+            Dimension? fontSize = null,
+            ColorBrush? textBrush = null) :
+            this(
+                initialValue,
+                new TextBlock(text, TextAlignmentType.Center)
+                {
+                    StyleClass = "CheckBox::TextElement",
+                    FontSize = fontSize ?? "1em",
+                    TextBrush = textBrush ?? new ColorBrush(new Color(0)),
+                    Layout =
+                        new ElementLayout()
+                            .SetMinMaxHeight(0, "100%")
+                            .SetMinMaxWidth(0, "100%", true),
+                    ElementContainerSizing = new RowContainerSizing(1f, VerticalAlignmentType.Center)
+                }
+            )
+        {
+        }
+
+        public override CheckBox Duplicate()
+        {
+            CheckBox el = new(Value, _textElement!, _indicatorElement)
+            {
+                Spacing = Spacing,
+                HorizontalArrangement = HorizontalArrangement,
+                VerticalAlignment = VerticalAlignment,
+                //BaseButton
+                CanUserCancelClick = CanUserCancelClick,
+                //
+                State = State,
+                Position = Position,
+                Background = Background.Duplicate(),
+                ClipPath = (ClipShape?)ClipPath?.Duplicate(),
+                ClipType = ClipType,
+                LocallyVisible = LocallyVisible,
+                LocallyEnabled = LocallyEnabled,
+                ElementContainerSizing = (ContainerSizing?)ElementContainerSizing?.Duplicate(),
+                Layout = Layout
+            };
+
+            DuplicateChildrenUtil(el);
+            return el;
+        }
+
+        private void PrivateOnClick(object sender, ClickEventArgs e)
+        {
+            if (Value == CheckBoxState.Unchecked || Value == CheckBoxState.Indeterminate)
+            {
+                Value = CheckBoxState.Checked;
+            }
+            else
+            {
+                Value = CheckBoxState.Unchecked;
+            }
+        }
+
+
+        public enum CheckBoxState
+        {
+            Unchecked = 0,
+            Checked = 1,
+            Indeterminate = 2
+        }
+    }
+}

--- a/src/CatUI.Elements/Buttons/RadioButton.cs
+++ b/src/CatUI.Elements/Buttons/RadioButton.cs
@@ -4,31 +4,21 @@ using CatUI.Data.Containers;
 using CatUI.Data.Containers.LinearContainers;
 using CatUI.Data.ElementData;
 using CatUI.Data.Enums;
+using CatUI.Data.Events.Input.Gestures;
 using CatUI.Data.Shapes;
 using CatUI.Elements.Behaviors;
 using CatUI.Elements.Containers.Linear;
-using CatUI.Elements.Media;
+using CatUI.Elements.ControlFlow;
 using CatUI.Elements.Shapes;
 using CatUI.Elements.Text;
-using CatUI.Elements.Utils;
 using CatUI.Utils;
 
 namespace CatUI.Elements.Buttons
 {
-    /// <summary>
-    /// A UI button that is specialized in having a text, an icon, or both. For a button that has any kind of
-    /// content, see <see cref="BaseButton"/>. Do NOT set the <see cref="Element.Children"/> directly or interfere in any
-    /// way with the first child, as it is used internally. Modifying it without using <see cref="TextElement"/> and
-    /// <see cref="IconElement"/> might result in crashes or unexpected behavior in general.
-    /// </summary>
-    /// <remarks>
-    /// <see cref="Element.Children"/> is controlled internally. You should never set or modify any children directly,
-    /// but use convenience properties and methods instead. Direct children modification might cause crashes.
-    /// </remarks>
-    public class Button : BaseButton, IPaddingAware
+    public class RadioButton : BaseButton, IToggleable
     {
         /// <inheritdoc cref="Element.Ref"/>
-        public new ObjectRef<Button>? Ref
+        public new ObjectRef<RadioButton>? Ref
         {
             get => _ref;
             set
@@ -41,26 +31,27 @@ namespace CatUI.Elements.Buttons
             }
         }
 
-        private ObjectRef<Button>? _ref;
+        private ObjectRef<RadioButton>? _ref;
 
-        public EdgeInset Padding
+        public bool Value
         {
-            get => _padding;
-            set => PaddingProperty.Value = value;
+            get => _value;
+            set => ValueProperty.Value = value;
         }
 
-        private EdgeInset _padding = new();
-        public ObservableProperty<EdgeInset> PaddingProperty { get; } = new(new EdgeInset());
+        private bool _value;
 
-        private void SetPadding(EdgeInset value)
+        public ObservableProperty<bool> ValueProperty { get; } = new(false);
+
+        private void SetValue(bool value)
         {
-            _padding = value;
-            SetLocalValue(nameof(Padding), value);
+            _value = value;
+            SetLocalValue(nameof(Value), value);
+            MarkLayoutDirty();
         }
 
         /// <summary>
-        /// Represents the spacing between <see cref="TextElement"/> and <see cref="IconElement"/>. This will be considered
-        /// only when both a text and an icon are given.
+        /// Represents the spacing between <see cref="IndicatorElement"/> and <see cref="TextElement"/>.
         /// </summary>
         public Dimension Spacing
         {
@@ -125,9 +116,8 @@ namespace CatUI.Elements.Buttons
         }
 
         /// <summary>
-        /// Represents the text content of the button, but it's optional, as you can have this, an <see cref="IconElement"/>
-        /// or both. Contrary to the name, this can be any kind of element, but it's much more common for it to be a
-        /// <see cref="TextBlock"/>.
+        /// Represents the text content of the radio button. Contrary to the name, this can be any kind of element, but
+        /// it's much more common for it to be a <see cref="TextBlock"/>.
         /// </summary>
         /// <remarks>
         /// In order to see when this is modified, assuming you don't interfere with <see cref="InternalRowContainer"/>'s
@@ -158,134 +148,137 @@ namespace CatUI.Elements.Buttons
                 }
 
                 _textElement = value;
-                InternalRowContainer.Children[_iconElement == null ? 0 : 1] = value;
+                InternalRowContainer.Children[1] = value;
             }
         }
 
         private Element? _textElement;
 
         /// <summary>
-        /// Represents content of the icon, but it's optional, as you can have this, an <see cref="TextElement"/> or both.
-        /// Contrary to the name, this can be any kind of element, but it's generally used as an icon, like a
-        /// <see cref="GeometricPathElement"/> or <see cref="ImageView"/>.
+        /// The actual visual indicator element (commonly a box with a check mark inside it). This cannot be null.
+        /// It always has to be present in the hierarchy.
         /// </summary>
-        /// <remarks>
-        /// In order to see when this is modified, assuming you don't interfere with <see cref="InternalRowContainer"/>'s
-        /// children, you can listen to <see cref="ObservableList{T}"/> events on <see cref="Element.Children"/> on
-        /// <see cref="InternalRowContainer"/>.
-        /// </remarks>
-        public Element? IconElement
+        public IfElement IndicatorElement
         {
-            get => _iconElement;
+            get => _indicatorElement;
             set
             {
-                if (_iconElement == null)
-                {
-                    _iconElement = value;
-                    if (value != null)
-                    {
-                        InternalRowContainer.Children.Insert(0, value);
-                    }
-
-                    return;
-                }
-
-                if (value == null)
-                {
-                    InternalRowContainer.Children.Remove(_iconElement);
-                    _iconElement = null;
-                    return;
-                }
-
-                _iconElement = value;
+                _indicatorElement = value;
                 InternalRowContainer.Children[0] = value;
+                //bind the indicator to the radio button value
+                value.Condition.BindBidirectional(ValueProperty);
             }
         }
 
-        private Element? _iconElement;
-
-        /// <summary>
-        /// Gives direct access to the button's <see cref="PaddingElement"/>. You should generally not modify this
-        /// and certainly not remove it from the document, but you have access to it just in case you need it.
-        /// </summary>
-        public PaddingElement InternalPaddingElement { get; }
+        private IfElement _indicatorElement = null!;
 
         /// <summary>
         /// Gives direct access to the button's <see cref="RowContainer"/>, which holds <see cref="TextElement"/> and
-        /// <see cref="IconElement"/>. You should generally not modify this and certainly not remove it from the document,
+        /// <see cref="IndicatorElement"/>. You should generally not modify this and certainly not remove it from the document,
         /// but you have access to it just in case you need it.
         /// </summary>
         /// <remarks>
-        /// Modifying properties from here won't reflect in properties of Button like <see cref="HorizontalArrangement"/>,
-        /// that's why you should always modify everything that's possible from Button properties, not from this container
-        /// directly.
+        /// Modifying properties here directly will not reflect in some properties of the RadioButton like
+        /// <see cref="HorizontalArrangement"/>, that's why you should always use the RadioButton properties instead of
+        /// manually modifying this RowContainer where possible.
         /// </remarks>
         public RowContainer InternalRowContainer { get; }
 
+        private readonly IfElement _defaultIndicatorElement =
+            new(
+                new ObservableProperty<bool>(false),
+                new EllipseElement(outlineBrush: new ColorBrush(new Color(0)))
+                {
+                    StyleClass = "RadioButton::Indicator::Active::Outer",
+                    Position = new Dimension2(1, 1),
+                    Layout = new ElementLayout().SetFixedWidth(18).SetFixedHeight(18),
+                    OutlineParameters = new OutlineParams(2f),
+                    ClipType = ClipApplicability.HitTesting,
+                    Children =
+                    [
+                        new EllipseElement(outlineBrush: new ColorBrush(new Color(0x00_80_ff)))
+                        {
+                            StyleClass = "RadioButton::Indicator::Active::Inner",
+                            Position = new Dimension2(4, 4),
+                            Layout = new ElementLayout().SetFixedWidth(10).SetFixedHeight(10),
+                            OutlineParameters = new OutlineParams(5f),
+                            ClipType = ClipApplicability.HitTesting
+                        }
+                    ]
+                },
+                new EllipseElement(outlineBrush: new ColorBrush(new Color(0)))
+                {
+                    StyleClass = "RadioButton::Indicator::Inactive::Outer",
+                    Position = new Dimension2(1, 1),
+                    Layout = new ElementLayout().SetFixedWidth(18).SetFixedHeight(18),
+                    OutlineParameters = new OutlineParams(2f),
+                    ClipType = ClipApplicability.HitTesting
+                }
+            ) { Layout = new ElementLayout().SetFixedWidth(20).SetFixedHeight(20) };
+
         /// <summary>
-        /// A constructor that creates a Button based on the given text element and icon element. Both are optional
-        /// because you can have a button with none of them, one of them (either text-only or icon-only) or both
-        /// (a text accompanied by an icon).
+        /// The base constructor. Will create a new radio button given an Element as <see cref="TextElement"/> and
+        /// a generic Element as the <see cref="IndicatorElement"/>. If indicatorElement is not given, it will be a
+        /// default element.
         /// </summary>
+        /// <param name="initialValue"></param>
         /// <param name="textElement">The value of <see cref="TextElement"/>.</param>
-        /// <param name="iconElement">The value of <see cref="IconElement"/>.</param>
-        public Button(Element? textElement = null, Element? iconElement = null)
+        /// <param name="indicatorElement">
+        /// The value of <see cref="IndicatorElement"/>, will be a default element if omitted.
+        /// </param>
+        public RadioButton(
+            bool initialValue,
+            Element textElement,
+            IfElement? indicatorElement = null)
         {
-            PaddingProperty.ValueChangedEvent += SetPadding;
+            OnClick += PrivateOnClick;
+
+            ValueProperty.ValueChangedEvent += SetValue;
             SpacingProperty.ValueChangedEvent += SetSpacing;
             HorizontalArrangementProperty.ValueChangedEvent += SetHorizontalArrangement;
             VerticalAlignmentProperty.ValueChangedEvent += SetVerticalAlignment;
-
-            _textElement = textElement;
-            _iconElement = iconElement;
 
             InternalRowContainer = new RowContainer
             {
                 Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%"),
                 Arrangement = new LinearArrangement(LinearArrangement.JustificationType.Center, 0),
-                VerticalAlignment = VerticalAlignmentType.Center
+                VerticalAlignment = VerticalAlignmentType.Center,
+                //we need to have at least one child, as IndicatorElement will access index 0 (this will be replaced
+                //when IndicatorElement are set, immediately in this constructor)
+                Children = [new Element()]
             };
 
-            if (_iconElement != null)
-            {
-                InternalRowContainer.Children.Add(_iconElement);
-            }
+            InternalRowContainer.VerticalAlignmentProperty.BindBidirectional(VerticalAlignmentProperty);
+            Children.Add(InternalRowContainer);
 
-            if (_textElement != null)
-            {
-                InternalRowContainer.Children.Add(_textElement);
-            }
+            indicatorElement ??= _defaultIndicatorElement;
+            IndicatorElement = indicatorElement;
 
-            InternalPaddingElement = new PaddingElement
-            {
-                Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%"),
-                Children = [InternalRowContainer]
-            };
-            Children.Add(InternalPaddingElement);
-
-            InternalPaddingElement.PaddingProperty.BindBidirectional(PaddingProperty);
+            TextElement = textElement;
+            Value = initialValue;
         }
 
         /// <summary>
-        /// A helper constructor that will set the <see cref="TextElement"/> as a default <see cref="TextBlock"/> with
-        /// the given text, font size and text brush and will give it a padding.
+        /// Creates a new radio button with <see cref="TextElement"/> as a new <see cref="TextBlock"/> with the given
+        /// properties.
         /// </summary>
+        /// <param name="initialValue">The initial value of the radio button.</param>
         /// <param name="text">
         /// The text that a <see cref="TextBlock"/> will have when set as the value of <see cref="TextElement"/>.
         /// </param>
         /// <param name="fontSize">The value of <see cref="Text.TextElement.FontSize"/>.</param>
         /// <param name="textBrush">The value of <see cref="TextBlock.TextBrush"/>.</param>
-        /// <param name="padding">The value of <see cref="Padding"/>.</param>
-        public Button(
+        public RadioButton(
+            bool initialValue,
             string text,
             Dimension? fontSize = null,
-            ColorBrush? textBrush = null,
-            EdgeInset? padding = null) :
+            ColorBrush? textBrush = null) :
             this(
+                initialValue,
                 new TextBlock(text, TextAlignmentType.Center)
                 {
-                    StyleClass = "Button::TextElement",
-                    FontSize = fontSize ?? 16,
+                    StyleClass = "RadioButton::TextElement",
+                    FontSize = fontSize ?? "1em",
                     TextBrush = textBrush ?? new ColorBrush(new Color(0)),
                     Layout =
                         new ElementLayout()
@@ -295,42 +288,12 @@ namespace CatUI.Elements.Buttons
                 }
             )
         {
-            if (padding != null)
-            {
-                Padding = padding.Value;
-            }
         }
 
-        /// <summary>
-        /// A helper constructor that will set the <see cref="IconElement"/> as a given <see cref="AbstractShapeElement"/>
-        /// and will give it padding.
-        /// </summary>
-        /// <param name="shapeElement">
-        /// A shape element that will be set as the value of <see cref="IconElement"/>.
-        /// </param>
-        /// <param name="padding">The value of <see cref="Padding"/>.</param>
-        public Button(AbstractShapeElement shapeElement, EdgeInset? padding = null) :
-            this(null, shapeElement)
+        public override RadioButton Duplicate()
         {
-            if (padding != null)
+            RadioButton el = new(Value, _textElement!, _indicatorElement)
             {
-                Padding = padding.Value;
-            }
-        }
-
-        //~Button()
-        //{
-        //    PaddingProperty = null!;
-        //    SpacingProperty = null!;
-        //    HorizontalArrangementProperty = null!;
-        //    VerticalAlignmentProperty = null!;
-        //}
-
-        public override Button Duplicate()
-        {
-            Button el = new(_textElement, _iconElement)
-            {
-                Padding = Padding,
                 Spacing = Spacing,
                 HorizontalArrangement = HorizontalArrangement,
                 VerticalAlignment = VerticalAlignment,
@@ -350,6 +313,11 @@ namespace CatUI.Elements.Buttons
 
             DuplicateChildrenUtil(el);
             return el;
+        }
+
+        private void PrivateOnClick(object sender, ClickEventArgs e)
+        {
+            Value = !Value;
         }
     }
 }

--- a/src/CatUI.Elements/Buttons/SwitchButton.cs
+++ b/src/CatUI.Elements/Buttons/SwitchButton.cs
@@ -4,31 +4,21 @@ using CatUI.Data.Containers;
 using CatUI.Data.Containers.LinearContainers;
 using CatUI.Data.ElementData;
 using CatUI.Data.Enums;
+using CatUI.Data.Events.Input.Gestures;
 using CatUI.Data.Shapes;
 using CatUI.Elements.Behaviors;
 using CatUI.Elements.Containers.Linear;
-using CatUI.Elements.Media;
+using CatUI.Elements.ControlFlow;
 using CatUI.Elements.Shapes;
 using CatUI.Elements.Text;
-using CatUI.Elements.Utils;
 using CatUI.Utils;
 
 namespace CatUI.Elements.Buttons
 {
-    /// <summary>
-    /// A UI button that is specialized in having a text, an icon, or both. For a button that has any kind of
-    /// content, see <see cref="BaseButton"/>. Do NOT set the <see cref="Element.Children"/> directly or interfere in any
-    /// way with the first child, as it is used internally. Modifying it without using <see cref="TextElement"/> and
-    /// <see cref="IconElement"/> might result in crashes or unexpected behavior in general.
-    /// </summary>
-    /// <remarks>
-    /// <see cref="Element.Children"/> is controlled internally. You should never set or modify any children directly,
-    /// but use convenience properties and methods instead. Direct children modification might cause crashes.
-    /// </remarks>
-    public class Button : BaseButton, IPaddingAware
+    public class SwitchButton : BaseButton, IToggleable
     {
         /// <inheritdoc cref="Element.Ref"/>
-        public new ObjectRef<Button>? Ref
+        public new ObjectRef<SwitchButton>? Ref
         {
             get => _ref;
             set
@@ -41,26 +31,27 @@ namespace CatUI.Elements.Buttons
             }
         }
 
-        private ObjectRef<Button>? _ref;
+        private ObjectRef<SwitchButton>? _ref;
 
-        public EdgeInset Padding
+        public bool Value
         {
-            get => _padding;
-            set => PaddingProperty.Value = value;
+            get => _value;
+            set => ValueProperty.Value = value;
         }
 
-        private EdgeInset _padding = new();
-        public ObservableProperty<EdgeInset> PaddingProperty { get; } = new(new EdgeInset());
+        private bool _value;
 
-        private void SetPadding(EdgeInset value)
+        public ObservableProperty<bool> ValueProperty { get; } = new(false);
+
+        private void SetValue(bool value)
         {
-            _padding = value;
-            SetLocalValue(nameof(Padding), value);
+            _value = value;
+            SetLocalValue(nameof(Value), value);
+            MarkLayoutDirty();
         }
 
         /// <summary>
-        /// Represents the spacing between <see cref="TextElement"/> and <see cref="IconElement"/>. This will be considered
-        /// only when both a text and an icon are given.
+        /// Represents the spacing between <see cref="IndicatorElement"/> and <see cref="TextElement"/>.
         /// </summary>
         public Dimension Spacing
         {
@@ -125,9 +116,8 @@ namespace CatUI.Elements.Buttons
         }
 
         /// <summary>
-        /// Represents the text content of the button, but it's optional, as you can have this, an <see cref="IconElement"/>
-        /// or both. Contrary to the name, this can be any kind of element, but it's much more common for it to be a
-        /// <see cref="TextBlock"/>.
+        /// Represents the text content of the radio button. Contrary to the name, this can be any kind of element, but
+        /// it's much more common for it to be a <see cref="TextBlock"/>.
         /// </summary>
         /// <remarks>
         /// In order to see when this is modified, assuming you don't interfere with <see cref="InternalRowContainer"/>'s
@@ -144,7 +134,7 @@ namespace CatUI.Elements.Buttons
                     _textElement = value;
                     if (value != null)
                     {
-                        InternalRowContainer.Children.Add(value);
+                        InternalRowContainer.Children.Insert(0, value);
                     }
 
                     return;
@@ -158,134 +148,153 @@ namespace CatUI.Elements.Buttons
                 }
 
                 _textElement = value;
-                InternalRowContainer.Children[_iconElement == null ? 0 : 1] = value;
+                InternalRowContainer.Children[0] = value;
             }
         }
 
         private Element? _textElement;
 
         /// <summary>
-        /// Represents content of the icon, but it's optional, as you can have this, an <see cref="TextElement"/> or both.
-        /// Contrary to the name, this can be any kind of element, but it's generally used as an icon, like a
-        /// <see cref="GeometricPathElement"/> or <see cref="ImageView"/>.
+        /// The actual visual indicator element (commonly a graphical element that looks like a switch). This cannot be
+        /// null. It always has to be present in the hierarchy.
         /// </summary>
-        /// <remarks>
-        /// In order to see when this is modified, assuming you don't interfere with <see cref="InternalRowContainer"/>'s
-        /// children, you can listen to <see cref="ObservableList{T}"/> events on <see cref="Element.Children"/> on
-        /// <see cref="InternalRowContainer"/>.
-        /// </remarks>
-        public Element? IconElement
+        public IfElement IndicatorElement
         {
-            get => _iconElement;
+            get => _indicatorElement;
             set
             {
-                if (_iconElement == null)
+                _indicatorElement = value;
+
+                if (_textElement == null)
                 {
-                    _iconElement = value;
-                    if (value != null)
+                    InternalRowContainer.Children[0] = value;
+                }
+                else
+                {
+                    if (InternalRowContainer.Children.Count == 2)
                     {
-                        InternalRowContainer.Children.Insert(0, value);
+                        InternalRowContainer.Children[1] = value;
                     }
-
-                    return;
+                    else
+                    {
+                        InternalRowContainer.Children.Add(value);
+                    }
                 }
 
-                if (value == null)
-                {
-                    InternalRowContainer.Children.Remove(_iconElement);
-                    _iconElement = null;
-                    return;
-                }
-
-                _iconElement = value;
-                InternalRowContainer.Children[0] = value;
+                //bind the indicator to the radio button value
+                value.Condition.BindBidirectional(ValueProperty);
             }
         }
 
-        private Element? _iconElement;
-
-        /// <summary>
-        /// Gives direct access to the button's <see cref="PaddingElement"/>. You should generally not modify this
-        /// and certainly not remove it from the document, but you have access to it just in case you need it.
-        /// </summary>
-        public PaddingElement InternalPaddingElement { get; }
+        private IfElement _indicatorElement = null!;
 
         /// <summary>
         /// Gives direct access to the button's <see cref="RowContainer"/>, which holds <see cref="TextElement"/> and
-        /// <see cref="IconElement"/>. You should generally not modify this and certainly not remove it from the document,
+        /// <see cref="IndicatorElement"/>. You should generally not modify this and certainly not remove it from the document,
         /// but you have access to it just in case you need it.
         /// </summary>
         /// <remarks>
-        /// Modifying properties from here won't reflect in properties of Button like <see cref="HorizontalArrangement"/>,
-        /// that's why you should always modify everything that's possible from Button properties, not from this container
-        /// directly.
+        /// Modifying properties here directly will not reflect in some properties of the SwitchButton like
+        /// <see cref="HorizontalArrangement"/>, that's why you should always use the SwitchButton properties instead of
+        /// manually modifying this RowContainer where possible.
         /// </remarks>
         public RowContainer InternalRowContainer { get; }
 
+        private readonly IfElement _defaultIndicatorElement =
+            new(
+                new ObservableProperty<bool>(false),
+                new EllipseElement(outlineBrush: new ColorBrush(new Color(0)))
+                {
+                    StyleClass = "SwitchButton::Indicator::Active::Outer",
+                    Position = new Dimension2(1, 1),
+                    Layout = new ElementLayout().SetFixedWidth(18).SetFixedHeight(18),
+                    OutlineParameters = new OutlineParams(2f),
+                    ClipType = ClipApplicability.HitTesting,
+                    Children =
+                    [
+                        new EllipseElement(outlineBrush: new ColorBrush(new Color(0x00_80_ff)))
+                        {
+                            StyleClass = "SwitchButton::Indicator::Active::Inner",
+                            Position = new Dimension2(4, 4),
+                            Layout = new ElementLayout().SetFixedWidth(10).SetFixedHeight(10),
+                            OutlineParameters = new OutlineParams(5f),
+                            ClipType = ClipApplicability.HitTesting
+                        }
+                    ]
+                },
+                new EllipseElement(outlineBrush: new ColorBrush(new Color(0)))
+                {
+                    StyleClass = "SwitchButton::Indicator::Inactive::Outer",
+                    Position = new Dimension2(1, 1),
+                    Layout = new ElementLayout().SetFixedWidth(18).SetFixedHeight(18),
+                    OutlineParameters = new OutlineParams(2f),
+                    ClipType = ClipApplicability.HitTesting
+                }
+            ) { Layout = new ElementLayout().SetFixedWidth(20).SetFixedHeight(20) };
+
         /// <summary>
-        /// A constructor that creates a Button based on the given text element and icon element. Both are optional
-        /// because you can have a button with none of them, one of them (either text-only or icon-only) or both
-        /// (a text accompanied by an icon).
+        /// The base constructor. Will create a new switch button given an Element as <see cref="TextElement"/> and
+        /// a generic Element as the <see cref="IndicatorElement"/>. If indicatorElement is not given, it will be a
+        /// default element.
         /// </summary>
+        /// <param name="initialValue"></param>
         /// <param name="textElement">The value of <see cref="TextElement"/>.</param>
-        /// <param name="iconElement">The value of <see cref="IconElement"/>.</param>
-        public Button(Element? textElement = null, Element? iconElement = null)
+        /// <param name="indicatorElement">
+        /// The value of <see cref="IndicatorElement"/>, will be a default element if omitted.
+        /// </param>
+        public SwitchButton(
+            bool initialValue,
+            Element textElement,
+            IfElement? indicatorElement = null)
         {
-            PaddingProperty.ValueChangedEvent += SetPadding;
+            OnClick += PrivateOnClick;
+
+            ValueProperty.ValueChangedEvent += SetValue;
             SpacingProperty.ValueChangedEvent += SetSpacing;
             HorizontalArrangementProperty.ValueChangedEvent += SetHorizontalArrangement;
             VerticalAlignmentProperty.ValueChangedEvent += SetVerticalAlignment;
-
-            _textElement = textElement;
-            _iconElement = iconElement;
 
             InternalRowContainer = new RowContainer
             {
                 Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%"),
                 Arrangement = new LinearArrangement(LinearArrangement.JustificationType.Center, 0),
-                VerticalAlignment = VerticalAlignmentType.Center
+                VerticalAlignment = VerticalAlignmentType.Center,
+                //we need to have at least one child, as IndicatorElement will access index 0 (this will be replaced
+                //when IndicatorElement are set, immediately in this constructor)
+                Children = [new Element()]
             };
 
-            if (_iconElement != null)
-            {
-                InternalRowContainer.Children.Add(_iconElement);
-            }
+            InternalRowContainer.VerticalAlignmentProperty.BindBidirectional(VerticalAlignmentProperty);
+            Children.Add(InternalRowContainer);
 
-            if (_textElement != null)
-            {
-                InternalRowContainer.Children.Add(_textElement);
-            }
+            indicatorElement ??= _defaultIndicatorElement;
+            IndicatorElement = indicatorElement;
 
-            InternalPaddingElement = new PaddingElement
-            {
-                Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%"),
-                Children = [InternalRowContainer]
-            };
-            Children.Add(InternalPaddingElement);
-
-            InternalPaddingElement.PaddingProperty.BindBidirectional(PaddingProperty);
+            TextElement = textElement;
+            Value = initialValue;
         }
 
         /// <summary>
-        /// A helper constructor that will set the <see cref="TextElement"/> as a default <see cref="TextBlock"/> with
-        /// the given text, font size and text brush and will give it a padding.
+        /// Creates a new switch button with <see cref="TextElement"/> as a new <see cref="TextBlock"/> with the given
+        /// properties.
         /// </summary>
+        /// <param name="initialValue">The initial value of the switch button.</param>
         /// <param name="text">
         /// The text that a <see cref="TextBlock"/> will have when set as the value of <see cref="TextElement"/>.
         /// </param>
         /// <param name="fontSize">The value of <see cref="Text.TextElement.FontSize"/>.</param>
         /// <param name="textBrush">The value of <see cref="TextBlock.TextBrush"/>.</param>
-        /// <param name="padding">The value of <see cref="Padding"/>.</param>
-        public Button(
+        public SwitchButton(
+            bool initialValue,
             string text,
             Dimension? fontSize = null,
-            ColorBrush? textBrush = null,
-            EdgeInset? padding = null) :
+            ColorBrush? textBrush = null) :
             this(
+                initialValue,
                 new TextBlock(text, TextAlignmentType.Center)
                 {
-                    StyleClass = "Button::TextElement",
-                    FontSize = fontSize ?? 16,
+                    StyleClass = "SwitchButton::TextElement",
+                    FontSize = fontSize ?? "1em",
                     TextBrush = textBrush ?? new ColorBrush(new Color(0)),
                     Layout =
                         new ElementLayout()
@@ -295,42 +304,12 @@ namespace CatUI.Elements.Buttons
                 }
             )
         {
-            if (padding != null)
-            {
-                Padding = padding.Value;
-            }
         }
 
-        /// <summary>
-        /// A helper constructor that will set the <see cref="IconElement"/> as a given <see cref="AbstractShapeElement"/>
-        /// and will give it padding.
-        /// </summary>
-        /// <param name="shapeElement">
-        /// A shape element that will be set as the value of <see cref="IconElement"/>.
-        /// </param>
-        /// <param name="padding">The value of <see cref="Padding"/>.</param>
-        public Button(AbstractShapeElement shapeElement, EdgeInset? padding = null) :
-            this(null, shapeElement)
+        public override SwitchButton Duplicate()
         {
-            if (padding != null)
+            SwitchButton el = new(Value, _textElement!, _indicatorElement)
             {
-                Padding = padding.Value;
-            }
-        }
-
-        //~Button()
-        //{
-        //    PaddingProperty = null!;
-        //    SpacingProperty = null!;
-        //    HorizontalArrangementProperty = null!;
-        //    VerticalAlignmentProperty = null!;
-        //}
-
-        public override Button Duplicate()
-        {
-            Button el = new(_textElement, _iconElement)
-            {
-                Padding = Padding,
                 Spacing = Spacing,
                 HorizontalArrangement = HorizontalArrangement,
                 VerticalAlignment = VerticalAlignment,
@@ -350,6 +329,11 @@ namespace CatUI.Elements.Buttons
 
             DuplicateChildrenUtil(el);
             return el;
+        }
+
+        private void PrivateOnClick(object sender, ClickEventArgs e)
+        {
+            Value = !Value;
         }
     }
 }

--- a/src/CatUI.Elements/Buttons/TriStateCheckBoxIndicator.cs
+++ b/src/CatUI.Elements/Buttons/TriStateCheckBoxIndicator.cs
@@ -1,0 +1,111 @@
+using CatUI.Data.Containers;
+using CatUI.Data.Shapes;
+using CatUI.Elements.ControlFlow;
+using CatUI.Utils;
+
+namespace CatUI.Elements.Buttons
+{
+    public class TriStateCheckBoxIndicator : SwitchElement<CheckBox.CheckBoxState>
+    {
+        /// <inheritdoc cref="Element.Ref"/>
+        public new ObjectRef<TriStateCheckBoxIndicator>? Ref
+        {
+            get => _ref;
+            set
+            {
+                _ref = value;
+                if (_ref != null)
+                {
+                    _ref.Value = this;
+                }
+            }
+        }
+
+        private ObjectRef<TriStateCheckBoxIndicator>? _ref;
+
+        /// <summary>
+        /// The element that appears when <see cref="SwitchElement{T}.Value"/> is
+        /// <see cref="CheckBox.CheckBoxState.Checked"/> (set automatically by <see cref="CheckBox"/> when used there).
+        /// </summary>
+        public Element CheckedElement
+        {
+            get => CaseLabels[0].MatchElementFunction.Invoke(CheckBox.CheckBoxState.Checked);
+            set
+            {
+                CaseLabels[0].MatchElementFunction = _ => value;
+                Reevaluate();
+            }
+        }
+
+        /// <summary>
+        /// The element that appears when <see cref="SwitchElement{T}.Value"/> is
+        /// <see cref="CheckBox.CheckBoxState.Unchecked"/> (set automatically by <see cref="CheckBox"/> when used there).
+        /// </summary>
+        public Element UncheckedElement
+        {
+            get => CaseLabels[1].MatchElementFunction.Invoke(CheckBox.CheckBoxState.Unchecked);
+            set
+            {
+                CaseLabels[1].MatchElementFunction = _ => value;
+                Reevaluate();
+            }
+        }
+
+        /// <summary>
+        /// The element that appears when <see cref="SwitchElement{T}.Value"/> is
+        /// <see cref="CheckBox.CheckBoxState.Indeterminate"/> (set automatically by <see cref="CheckBox"/> when
+        /// used there). If it's not set, Indeterminate will equal to <see cref="CheckBox.CheckBoxState.Unchecked"/>.
+        /// </summary>
+        public Element? IndeterminateElement
+        {
+            get =>
+                _isIndeterminateSet
+                    ? CaseLabels[2].MatchElementFunction.Invoke(CheckBox.CheckBoxState.Indeterminate)
+                    : null;
+            set
+            {
+                CaseLabels[2].MatchElementFunction = _ => value ?? new Element();
+                _isIndeterminateSet = value != null;
+                Reevaluate();
+            }
+        }
+
+        private bool _isIndeterminateSet;
+
+        public TriStateCheckBoxIndicator(
+            CheckBox.CheckBoxState initialValue,
+            Element checkedElement,
+            Element uncheckedElement,
+            Element? indeterminateElement = null)
+            : base(initialValue)
+        {
+            CaseLabels.Add(new ExactCaseLabel(CheckBox.CheckBoxState.Checked, _ => checkedElement));
+            CaseLabels.Add(new ExactCaseLabel(CheckBox.CheckBoxState.Unchecked, _ => uncheckedElement));
+            CaseLabels.Add(new ExactCaseLabel(CheckBox.CheckBoxState.Indeterminate,
+                _ => indeterminateElement ?? new Element()));
+
+            _isIndeterminateSet = indeterminateElement != null;
+            Reevaluate();
+        }
+
+        public override TriStateCheckBoxIndicator Duplicate()
+        {
+            TriStateCheckBoxIndicator el = new(Value, CheckedElement, UncheckedElement, IndeterminateElement)
+            {
+                //
+                State = State,
+                Position = Position,
+                Background = Background.Duplicate(),
+                ClipPath = (ClipShape?)ClipPath?.Duplicate(),
+                ClipType = ClipType,
+                LocallyVisible = LocallyVisible,
+                LocallyEnabled = LocallyEnabled,
+                ElementContainerSizing = (ContainerSizing?)ElementContainerSizing?.Duplicate(),
+                Layout = Layout
+            };
+
+            DuplicateChildrenUtil(el);
+            return el;
+        }
+    }
+}

--- a/src/CatUI.Elements/Containers/Linear/LinearContainerBase.cs
+++ b/src/CatUI.Elements/Containers/Linear/LinearContainerBase.cs
@@ -10,9 +10,9 @@ namespace CatUI.Elements.Containers.Linear
     public abstract partial class LinearContainerBase : Container
     {
         /// <summary>
-        /// Specifies the arrangement of the children of this container. It only refers to the axis of orientation
+        /// Specifies the arrangement this container's children. It only refers to the axis of orientation
         /// (i.e. <see cref="ContainerOrientation"/>, meaning horizontal for <see cref="RowContainer"/>, vertical
-        /// for <see cref="ColumnContainer"/>); for the other axis, see ...
+        /// for <see cref="ColumnContainer"/>); for the other axis, see <see cref="PreferredAlignment"/>.
         /// </summary>
         public LinearArrangement Arrangement
         {
@@ -32,6 +32,11 @@ namespace CatUI.Elements.Containers.Linear
             MarkLayoutDirty();
         }
 
+        /// <summary>
+        /// The default alignment on the opposite axis of orientation. This is the value of
+        /// <see cref="ColumnContainer.HorizontalAlignment"/> in the <see cref="ColumnContainer"/> and
+        /// <see cref="RowContainer.VerticalAlignment"/> in the <see cref="RowContainer"/>.
+        /// </summary>
         protected AlignmentType PreferredAlignment { get; set; } = AlignmentType.Start;
 
         /// <summary>

--- a/src/CatUI.Elements/Containers/Scroll/HorizontalScrollBar.cs
+++ b/src/CatUI.Elements/Containers/Scroll/HorizontalScrollBar.cs
@@ -24,9 +24,11 @@ namespace CatUI.Elements.Containers.Scroll
                     "M 15 2 L 5 10 L 15 18",
                     outlineBrush: new ColorBrush(new Color(0xFF_FF_FF)))
                 {
+                    StyleClass = "HorizontalScrollBar::PlusButton::Graphic",
                     Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%")
                 })
             {
+                StyleClass = "HorizontalScrollBar::PlusButton",
                 Layout = new ElementLayout().SetFixedWidth(20).SetFixedHeight(20),
                 Background = new ColorBrush(new Color(0x8C_8C_8C))
             };
@@ -43,9 +45,11 @@ namespace CatUI.Elements.Containers.Scroll
                     "M 5 2 L 15 10 L 5 18",
                     outlineBrush: new ColorBrush(new Color(0xFF_FF_FF)))
                 {
+                    StyleClass = "HorizontalScrollBar::MinusButton::Graphic",
                     Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%")
                 })
             {
+                StyleClass = "HorizontalScrollBar::MinusButton",
                 Layout = new ElementLayout().SetFixedWidth(20).SetFixedHeight(20),
                 Background = new ColorBrush(new Color(0x8C_8C_8C))
             };

--- a/src/CatUI.Elements/Containers/Scroll/VerticalScrollBar.cs
+++ b/src/CatUI.Elements/Containers/Scroll/VerticalScrollBar.cs
@@ -24,9 +24,11 @@ namespace CatUI.Elements.Containers.Scroll
                     "M 2 15 L 10 5 L 18 15",
                     outlineBrush: new ColorBrush(new Color(0xFF_FF_FF)))
                 {
+                    StyleClass = "VerticalScrollBar::DownButton::Graphic",
                     Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%")
                 })
             {
+                StyleClass = "VerticalScrollBar::DownButton",
                 Layout = new ElementLayout().SetFixedWidth(20).SetFixedHeight(20),
                 Background = new ColorBrush(new Color(0x8C_8C_8C))
             };
@@ -43,9 +45,11 @@ namespace CatUI.Elements.Containers.Scroll
                     "M 2 5 L 10 15 L 18 5",
                     outlineBrush: new ColorBrush(new Color(0xFF_FF_FF)))
                 {
+                    StyleClass = "VerticalScrollBar::UpButton::Graphic",
                     Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%")
                 })
             {
+                StyleClass = "VerticalScrollBar::UpButton",
                 Layout = new ElementLayout().SetFixedWidth(20).SetFixedHeight(20),
                 Background = new ColorBrush(new Color(0x8C_8C_8C))
             };

--- a/src/CatUI.Elements/Element.cs
+++ b/src/CatUI.Elements/Element.cs
@@ -687,6 +687,11 @@ namespace CatUI.Elements
             e.Item._parent = this;
             e.Item.IndexInParent = e.Index;
 
+            for (int i = e.Index + 1; i < Children.Count; i++)
+            {
+                Children[i].IndexInParent++;
+            }
+
             if (Document != null)
             {
                 e.Item.Document = Document;
@@ -705,6 +710,11 @@ namespace CatUI.Elements
             e.Item._parent = null;
             e.Item.IndexInParent = -1;
             e.Item.Bounds = new Rect();
+
+            for (int i = e.Index + 1; i < Children.Count; i++)
+            {
+                Children[i].IndexInParent--;
+            }
 
             e.Item._document = null;
             MarkLayoutDirty();

--- a/src/CatUI.Elements/Shapes/EllipseElement.cs
+++ b/src/CatUI.Elements/Shapes/EllipseElement.cs
@@ -72,16 +72,15 @@ namespace CatUI.Elements.Shapes
             //also draw the background
             base.DrawBackground();
 
-            if (FillBrush.IsSkippable)
+            if (!FillBrush.IsSkippable)
             {
-                return;
+                Document?.Renderer.DrawEllipse(
+                    new Point2D(Bounds.CenterX, Bounds.CenterY),
+                    Bounds.Width / 2f,
+                    Bounds.Height / 2f,
+                    FillBrush);
             }
 
-            Document?.Renderer.DrawEllipse(
-                new Point2D(Bounds.CenterX, Bounds.CenterY),
-                Bounds.Width / 2f,
-                Bounds.Height / 2f,
-                FillBrush);
 
             if (OutlineBrush.IsSkippable || OutlineParameters.OutlineWidth == 0)
             {

--- a/src/CatUI.Elements/Shapes/RectangleElement.cs
+++ b/src/CatUI.Elements/Shapes/RectangleElement.cs
@@ -11,7 +11,7 @@ namespace CatUI.Elements.Shapes
     /// <summary>
     /// Draws a rectangle, either filled, outlined or both. If the rectangle is both filled and outlined, the filled
     /// area will have the size of the element and the outline will exceed the element bounds by half of the outline width
-    /// on each size. The outline will also overlap with the filled area by half of the outline width on each side.
+    /// on each side. The outline will also overlap with the filled area by half of the outline width on each side.
     /// </summary>
     public class RectangleElement : AbstractShapeElement
     {
@@ -59,7 +59,7 @@ namespace CatUI.Elements.Shapes
 
         protected override void DrawBackground()
         {
-            if (!IsCurrentlyVisible || FillBrush.IsSkippable)
+            if (!IsCurrentlyVisible)
             {
                 return;
             }

--- a/src/CatUI/IndirectAssets/README.md
+++ b/src/CatUI/IndirectAssets/README.md
@@ -1,0 +1,4 @@
+# IndirectAssets folder
+
+This contains assets that are used in CatUI, but not directly referenced. For example, SVG files that where only the
+path data is used, not the whole file.

--- a/src/CatUI/IndirectAssets/checkmark.svg
+++ b/src/CatUI/IndirectAssets/checkmark.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+
+<svg
+   fill="#000000"
+   version="1.1"
+   id="Capa_1"
+   width="20"
+   height="20"
+   viewBox="0 0 20 20"
+   xml:space="preserve"
+   sodipodi:docname="check-mark-svgrepo-com.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs2" /><sodipodi:namedview
+   id="namedview2"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="31.96"
+   inkscape:cx="5.9918648"
+   inkscape:cy="10.215895"
+   inkscape:window-width="1920"
+   inkscape:window-height="1008"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Capa_1" />
+<g
+   id="g2">
+	<g
+   id="g1">
+		<path
+   d="m 9.118746,16.621968 c -0.892928,0.892928 -2.341566,0.892713 -3.2342794,0 C 4.2141044,14.951606 2.5437422,13.281244 0.87338,11.610881 c -0.8927129,-0.892713 -0.8927129,-2.341136 0,-3.2338485 0.892713,-0.8927129 2.3412869,-0.892864 3.2342797,0 0.9952072,0.9950635 1.9904144,1.9901275 2.9856213,2.9851905 0.225188,0.225156 0.591694,0.225387 0.817082,0 2.69473,-2.6947302 5.38946,-5.3894605 8.084191,-8.0841909 0.892712,-0.8927129 2.341351,-0.8929284 3.234279,0 0.428796,0.4287953 0.669697,1.0105778 0.669697,1.6169244 0,0.6063467 -0.240901,1.1881292 -0.669697,1.6169244 C 15.858804,9.88191 12.488775,13.251939 9.118746,16.621968 Z"
+   id="path1"
+   sodipodi:nodetypes="ssssssssssss"
+   style="stroke-width:0.43095" />
+	</g>
+</g>
+</svg>

--- a/src/CatUI/IndirectAssets/radio-button.svg
+++ b/src/CatUI/IndirectAssets/radio-button.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="20"
+   height="20"
+   viewBox="0 0 20 20"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   sodipodi:docname="radio-button.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="22.777329"
+     inkscape:cx="4.8513151"
+     inkscape:cy="16.924724"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       id="rect1"
+       style="stroke-width:1.7611"
+       d="m 5,7 h 10 c 1.662,0 3,1.338 3,3 0,1.662 -1.338,3 -3,3 H 5 C 3.338,13 2,11.662 2,10 2,8.338 3.338,7 5,7 Z" />
+  </g>
+</svg>

--- a/src/CoreExtensions/CatUI.CoreExtensions.Itania/ItaniaTheme.cs
+++ b/src/CoreExtensions/CatUI.CoreExtensions.Itania/ItaniaTheme.cs
@@ -6,6 +6,7 @@ using CatUI.Data.Theming;
 using CatUI.Elements;
 using CatUI.Elements.Buttons;
 using CatUI.Elements.Containers.Scroll;
+using CatUI.Elements.Shapes;
 using CatUI.Elements.Text;
 
 namespace CatUI.CoreExtensions.Itania
@@ -17,17 +18,14 @@ namespace CatUI.CoreExtensions.Itania
             Theme theme = new();
 
             //text
-            theme.AddOrUpdateElementTypeDefinition(
-                typeof(TextElement),
+            theme.AddOrUpdateElementTypeDefinition<TextElement>(
                 new ThemeDefinition(el => ((TextElement)el).FontSize = "1em"));
 
-            theme.AddOrUpdateElementTypeDefinition(
-                typeof(TextBlock),
+            theme.AddOrUpdateElementTypeDefinition<TextBlock>(
                 new ThemeDefinition(el => ((TextBlock)el).TextBrush = new ColorBrush(CatTheme.Colors.OnSurface)));
 
             //scroll
-            theme.AddOrUpdateElementTypeDefinition(
-                typeof(ScrollContainer),
+            theme.AddOrUpdateElementTypeDefinition<ScrollContainer>(
                 new ThemeDefinition(el =>
                 {
                     var container = (ScrollContainer)el;
@@ -35,8 +33,7 @@ namespace CatUI.CoreExtensions.Itania
                     container.InternalVerticalScrollBar.Layout?.SetFixedWidth(12);
 
                     Theme scrollBarTheme = new();
-                    scrollBarTheme.AddOrUpdateElementTypeDefinition(
-                        typeof(ScrollBarBase),
+                    scrollBarTheme.AddOrUpdateElementTypeDefinition<ScrollBarBase>(
                         new ThemeDefinition(e =>
                         {
                             var scrollBar = (ScrollBarBase)e;
@@ -47,8 +44,7 @@ namespace CatUI.CoreExtensions.Itania
 
                             //override the button style from the scroll bar itself
                             Theme selfButtonTheme = new();
-                            selfButtonTheme.AddOrUpdateElementTypeDefinition(
-                                typeof(Button),
+                            selfButtonTheme.AddOrUpdateElementTypeDefinition<Button>(
                                 new ThemeDefinition(barButton =>
                                 {
                                     var btn = (Button)barButton;
@@ -62,8 +58,7 @@ namespace CatUI.CoreExtensions.Itania
                 }));
 
             //button
-            theme.AddOrUpdateElementTypeDefinition(
-                typeof(Button),
+            theme.AddOrUpdateElementTypeDefinition<Button>(
                 new ThemeDefinition(el =>
                 {
                     var btn = (Button)el;
@@ -71,6 +66,42 @@ namespace CatUI.CoreExtensions.Itania
                     btn.Padding = new EdgeInset(5, 7);
                     btn.ClipPath = new RoundedRectangleClipShape(8);
                     btn.Background = new ColorBrush(CatTheme.Colors.Primary);
+                }));
+
+            //checkbox
+            theme.AddOrUpdateElementTypeDefinition<CheckBox>(
+                new ThemeDefinition(el =>
+                {
+                    //TODO: Itania needs to provide its own indicator element, as the default one has direct local
+                    //properties set, meaning we can't modify those from a theme 
+                    var checkBox = (CheckBox)el;
+                    checkBox.Spacing = 10;
+
+                    Theme checkboxIndicatorTheme = new();
+
+                    var boxOutlineTheme = new ThemeDefinition(boxOutline =>
+                    {
+                        var rect = (RectangleElement)boxOutline;
+                        rect.OutlineBrush = new ColorBrush(CatTheme.Colors.Outline);
+                    });
+                    checkboxIndicatorTheme.AddOrUpdateClassDefinition(
+                        "CheckBox::Indicator::Checked::Outer", boxOutlineTheme);
+                    checkboxIndicatorTheme.AddOrUpdateClassDefinition(
+                        "CheckBox::Indicator::Unchecked::Outer", boxOutlineTheme);
+                    checkboxIndicatorTheme.AddOrUpdateClassDefinition(
+                        "CheckBox::Indicator::Indeterminate::Outer", boxOutlineTheme);
+
+                    var boxColoredSectionTheme = new ThemeDefinition(boxColoredSection =>
+                    {
+                        var rect = (RectangleElement)boxColoredSection;
+                        rect.FillBrush = new ColorBrush(CatTheme.Colors.Primary);
+                    });
+                    checkboxIndicatorTheme.AddOrUpdateClassDefinition(
+                        "CheckBox::Indicator::Checked::Inner", boxColoredSectionTheme);
+                    checkboxIndicatorTheme.AddOrUpdateClassDefinition(
+                        "CheckBox::Indicator::Indeterminate::Inner", boxColoredSectionTheme);
+
+                    checkBox.IndicatorElement.ThemeOverride = checkboxIndicatorTheme;
                 }));
             return theme;
         }


### PR DESCRIPTION
- Fix #158 with checkboxes, radio buttons and switches (limited Itania support for now)
- Add examples for these new controls in CatUISample
- Fix a bug regarding the outline not being drawn if fill wasn't set in RectangleElement and EllipseElement
- Fix a serious bug regarding removing elements: sibling elements were not having their IndexInParent updated, causing errors