### PR TITLE
Add RoundedRectangleElement and multiple changes

### DIFF
--- a/samples/CatUISample/CatUISample.UI/Pages/MainPage.cs
+++ b/samples/CatUISample/CatUISample.UI/Pages/MainPage.cs
@@ -1,8 +1,10 @@
+using CatUI.Data;
 using CatUI.Data.Brushes;
 using CatUI.Data.ElementData;
 using CatUI.Data.Enums;
 using CatUI.Data.Theming;
 using CatUI.Elements.Containers.Linear;
+using CatUI.Elements.Shapes;
 using CatUI.Elements.Text;
 
 namespace CatUISample.UI.Pages
@@ -11,7 +13,7 @@ namespace CatUISample.UI.Pages
     {
         public MainPage()
         {
-            Layout = new ElementLayout().SetFixedWidth("100%");
+            Layout = new ElementLayout().SetFixedWidth("100%").SetFixedHeight("100%");
         }
 
         protected override void EnterDocument(object sender)
@@ -25,6 +27,20 @@ namespace CatUISample.UI.Pages
                     Layout = new ElementLayout().SetMinMaxWidth(0, "100%", true),
                     FontSize = 32,
                     TextBrush = new ColorBrush(CatTheme.Colors.OnSurface)
+                },
+                new RoundedRectangleElement(
+                    new ColorBrush(new Color(0xff_00_00)),
+                    new ColorBrush(new Color(0xff_ff_ff)))
+                {
+                    Layout = new ElementLayout().SetFixedWidth("50%").SetFixedHeight("20%"),
+                    OutlineParameters = new OutlineParams(10f),
+                    RoundCornersDescriptor = new CornerInset
+                    {
+                        TopLeftRadius = 10,
+                        TopRightRadius = 15,
+                        BottomRightEllipse = new Dimension2(20, 10),
+                        BottomLeftEllipse = new Dimension2(25, 15)
+                    }
                 }
             ];
         }

--- a/src/CatUI.Data/ElementData/CornerInset.cs
+++ b/src/CatUI.Data/ElementData/CornerInset.cs
@@ -1,4 +1,7 @@
-﻿namespace CatUI.Data.ElementData
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace CatUI.Data.ElementData
 {
     /// <summary>
     /// A set of offsets in each of the 4 rectangle corners: top-left, top-right, bottom-right, bottom-left.
@@ -6,7 +9,7 @@
     /// <remarks>
     /// This is generally used for corner radius.
     /// </remarks>
-    public class CornerInset
+    public class CornerInset : INotifyPropertyChanged
     {
         /// <summary>
         /// Represents the radius of the top-left corner. Default is <see cref="Dimension.Unset"/> or 0. Setting this
@@ -22,6 +25,7 @@
                 if (value != Dimension.Unset)
                 {
                     _topLeftEllipse = Dimension2.Unset;
+                    NotifyPropertyChanged();
                 }
             }
         }
@@ -42,6 +46,7 @@
                 if (value != Dimension.Unset)
                 {
                     _topRightEllipse = Dimension2.Unset;
+                    NotifyPropertyChanged();
                 }
             }
         }
@@ -62,6 +67,7 @@
                 if (value != Dimension.Unset)
                 {
                     _bottomLeftEllipse = Dimension2.Unset;
+                    NotifyPropertyChanged();
                 }
             }
         }
@@ -82,6 +88,7 @@
                 if (value != Dimension.Unset)
                 {
                     _bottomRightEllipse = Dimension2.Unset;
+                    NotifyPropertyChanged();
                 }
             }
         }
@@ -103,6 +110,7 @@
                 if (value != Dimension2.Unset)
                 {
                     _topLeftRadius = Dimension.Unset;
+                    NotifyPropertyChanged();
                 }
             }
         }
@@ -124,6 +132,7 @@
                 if (value != Dimension2.Unset)
                 {
                     _topRightRadius = Dimension.Unset;
+                    NotifyPropertyChanged();
                 }
             }
         }
@@ -145,6 +154,7 @@
                 if (value != Dimension2.Unset)
                 {
                     _bottomLeftRadius = Dimension.Unset;
+                    NotifyPropertyChanged();
                 }
             }
         }
@@ -166,11 +176,14 @@
                 if (value != Dimension2.Unset)
                 {
                     _bottomRightRadius = Dimension.Unset;
+                    NotifyPropertyChanged();
                 }
             }
         }
 
         private Dimension2 _bottomRightEllipse = Dimension2.Unset;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         /// <summary>
         /// If true, it means that at least one of the corners has a value that is NOT 0.
@@ -282,6 +295,11 @@
                 BottomLeftRadius = BottomLeftRadius,
                 BottomRightRadius = BottomRightRadius
             };
+        }
+
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/src/CatUI.Data/Shapes/RoundedRectangleClipShape.cs
+++ b/src/CatUI.Data/Shapes/RoundedRectangleClipShape.cs
@@ -1,173 +1,176 @@
 using System;
+using CatUI.Data.ElementData;
 using SkiaSharp;
 
 namespace CatUI.Data.Shapes
 {
     public class RoundedRectangleClipShape : ClipShape
     {
-        /// <summary>
-        /// Represents the radius of the top-left corner. Default is <see cref="Dimension.Unset"/> or 0. Setting this
-        /// to anything other than <see cref="Dimension.Unset"/> will overwrite the value of <see cref="TopLeftEllipse"/>
-        /// to be <see cref="Dimension2.Unset"/>.
-        /// </summary>
-        public Dimension TopLeftRadius
-        {
-            get => _topLeftRadius;
-            set
-            {
-                _topLeftRadius = value;
-                if (value != Dimension.Unset)
-                {
-                    _topLeftEllipse = Dimension2.Unset;
-                }
-            }
-        }
+        // /// <summary>
+        // /// Represents the radius of the top-left corner. Default is <see cref="Dimension.Unset"/> or 0. Setting this
+        // /// to anything other than <see cref="Dimension.Unset"/> will overwrite the value of <see cref="TopLeftEllipse"/>
+        // /// to be <see cref="Dimension2.Unset"/>.
+        // /// </summary>
+        // public Dimension TopLeftRadius
+        // {
+        //     get => _topLeftRadius;
+        //     set
+        //     {
+        //         _topLeftRadius = value;
+        //         if (value != Dimension.Unset)
+        //         {
+        //             _topLeftEllipse = Dimension2.Unset;
+        //         }
+        //     }
+        // }
+        //
+        // private Dimension _topLeftRadius = Dimension.Unset;
+        //
+        // /// <summary>
+        // /// Represents the radius of the top-right corner. Default is <see cref="Dimension.Unset"/> or 0. Setting this
+        // /// to anything other than <see cref="Dimension.Unset"/> will overwrite the value of <see cref="TopRightEllipse"/>
+        // /// to be <see cref="Dimension2.Unset"/>.
+        // /// </summary>
+        // public Dimension TopRightRadius
+        // {
+        //     get => _topRightRadius;
+        //     set
+        //     {
+        //         _topRightRadius = value;
+        //         if (value != Dimension.Unset)
+        //         {
+        //             _topRightEllipse = Dimension2.Unset;
+        //         }
+        //     }
+        // }
+        //
+        // private Dimension _topRightRadius = Dimension.Unset;
+        //
+        // /// <summary>
+        // /// Represents the radius of the bottom-left corner. Default is <see cref="Dimension.Unset"/> or 0. Setting this
+        // /// to anything other than <see cref="Dimension.Unset"/> will overwrite the value of <see cref="BottomLeftEllipse"/>
+        // /// to be <see cref="Dimension2.Unset"/>.
+        // /// </summary>
+        // public Dimension BottomLeftRadius
+        // {
+        //     get => _bottomLeftRadius;
+        //     set
+        //     {
+        //         _bottomLeftRadius = value;
+        //         if (value != Dimension.Unset)
+        //         {
+        //             _bottomLeftEllipse = Dimension2.Unset;
+        //         }
+        //     }
+        // }
+        //
+        // private Dimension _bottomLeftRadius = Dimension.Unset;
+        //
+        // /// <summary>
+        // /// Represents the radius of the bottom-right corner. Default is <see cref="Dimension.Unset"/> or 0. Setting this
+        // /// to anything other than <see cref="Dimension.Unset"/> will overwrite the value of <see cref="BottomRightEllipse"/>
+        // /// to be <see cref="Dimension2.Unset"/>.
+        // /// </summary>
+        // public Dimension BottomRightRadius
+        // {
+        //     get => _bottomRightRadius;
+        //     set
+        //     {
+        //         _bottomRightRadius = value;
+        //         if (value != Dimension.Unset)
+        //         {
+        //             _bottomRightEllipse = Dimension2.Unset;
+        //         }
+        //     }
+        // }
+        //
+        // private Dimension _bottomRightRadius = Dimension.Unset;
+        //
+        // /// <summary>
+        // /// The X is the corner's ellipse X axis half-value, and the Y is the corner's ellipse Y axis half-value for
+        // /// the top-left corner. Default is <see cref="Dimension2.Unset"/> as normally the more simple, circle corners are used.
+        // /// Setting this anything other than <see cref="Dimension2.Unset"/> will override the simple value
+        // /// (<see cref="TopLeftRadius"/>).
+        // /// </summary>
+        // public Dimension2 TopLeftEllipse
+        // {
+        //     get => _topLeftEllipse;
+        //     set
+        //     {
+        //         _topLeftEllipse = value;
+        //         if (value != Dimension2.Unset)
+        //         {
+        //             _topLeftRadius = Dimension.Unset;
+        //         }
+        //     }
+        // }
+        //
+        // private Dimension2 _topLeftEllipse = Dimension2.Unset;
+        //
+        // /// <summary>
+        // /// The X is the corner's ellipse X axis half-value and the Y is the corner's ellipse Y axis half-value for
+        // /// the top-right corner. Default is <see cref="Dimension2.Unset"/> as normally the more simple, circle corners are used.
+        // /// Setting this anything other than <see cref="Dimension2.Unset"/> will override the simple value
+        // /// (<see cref="TopRightRadius"/>).
+        // /// </summary>
+        // public Dimension2 TopRightEllipse
+        // {
+        //     get => _topRightEllipse;
+        //     set
+        //     {
+        //         _topRightEllipse = value;
+        //         if (value != Dimension2.Unset)
+        //         {
+        //             _topRightRadius = Dimension.Unset;
+        //         }
+        //     }
+        // }
+        //
+        // private Dimension2 _topRightEllipse = Dimension2.Unset;
+        //
+        // /// <summary>
+        // /// The X is the corner's ellipse X axis half-value, and the Y is the corner's ellipse Y axis half-value for
+        // /// the bottom-left corner. Default is <see cref="Dimension2.Unset"/> as normally the more simple, circle corners are used.
+        // /// Setting this anything other than <see cref="Dimension2.Unset"/> will override the simple value
+        // /// (<see cref="BottomLeftRadius"/>).
+        // /// </summary>
+        // public Dimension2 BottomLeftEllipse
+        // {
+        //     get => _bottomLeftEllipse;
+        //     set
+        //     {
+        //         _bottomLeftEllipse = value;
+        //         if (value != Dimension2.Unset)
+        //         {
+        //             _bottomLeftRadius = Dimension.Unset;
+        //         }
+        //     }
+        // }
+        //
+        // private Dimension2 _bottomLeftEllipse = Dimension2.Unset;
+        //
+        // /// <summary>
+        // /// The X is the corner's ellipse X axis half-value, and the Y is the corner's ellipse Y axis half-value for
+        // /// the bottom-right corner. Default is <see cref="Dimension2.Unset"/> as normally the more simple, circle corners are used.
+        // /// Setting this anything other than <see cref="Dimension2.Unset"/> will override the simple value
+        // /// (<see cref="BottomRightRadius"/>).
+        // /// </summary>
+        // public Dimension2 BottomRightEllipse
+        // {
+        //     get => _bottomRightEllipse;
+        //     set
+        //     {
+        //         _bottomRightEllipse = value;
+        //         if (value != Dimension2.Unset)
+        //         {
+        //             _bottomRightRadius = Dimension.Unset;
+        //         }
+        //     }
+        // }
+        //
+        // private Dimension2 _bottomRightEllipse = Dimension2.Unset;
 
-        private Dimension _topLeftRadius = Dimension.Unset;
-
-        /// <summary>
-        /// Represents the radius of the top-right corner. Default is <see cref="Dimension.Unset"/> or 0. Setting this
-        /// to anything other than <see cref="Dimension.Unset"/> will overwrite the value of <see cref="TopRightEllipse"/>
-        /// to be <see cref="Dimension2.Unset"/>.
-        /// </summary>
-        public Dimension TopRightRadius
-        {
-            get => _topRightRadius;
-            set
-            {
-                _topRightRadius = value;
-                if (value != Dimension.Unset)
-                {
-                    _topRightEllipse = Dimension2.Unset;
-                }
-            }
-        }
-
-        private Dimension _topRightRadius = Dimension.Unset;
-
-        /// <summary>
-        /// Represents the radius of the bottom-left corner. Default is <see cref="Dimension.Unset"/> or 0. Setting this
-        /// to anything other than <see cref="Dimension.Unset"/> will overwrite the value of <see cref="BottomLeftEllipse"/>
-        /// to be <see cref="Dimension2.Unset"/>.
-        /// </summary>
-        public Dimension BottomLeftRadius
-        {
-            get => _bottomLeftRadius;
-            set
-            {
-                _bottomLeftRadius = value;
-                if (value != Dimension.Unset)
-                {
-                    _bottomLeftEllipse = Dimension2.Unset;
-                }
-            }
-        }
-
-        private Dimension _bottomLeftRadius = Dimension.Unset;
-
-        /// <summary>
-        /// Represents the radius of the bottom-right corner. Default is <see cref="Dimension.Unset"/> or 0. Setting this
-        /// to anything other than <see cref="Dimension.Unset"/> will overwrite the value of <see cref="BottomRightEllipse"/>
-        /// to be <see cref="Dimension2.Unset"/>.
-        /// </summary>
-        public Dimension BottomRightRadius
-        {
-            get => _bottomRightRadius;
-            set
-            {
-                _bottomRightRadius = value;
-                if (value != Dimension.Unset)
-                {
-                    _bottomRightEllipse = Dimension2.Unset;
-                }
-            }
-        }
-
-        private Dimension _bottomRightRadius = Dimension.Unset;
-
-        /// <summary>
-        /// The X is the corner's ellipse X axis half-value, and the Y is the corner's ellipse Y axis half-value for
-        /// the top-left corner. Default is <see cref="Dimension2.Unset"/> as normally the more simple, circle corners are used.
-        /// Setting this anything other than <see cref="Dimension2.Unset"/> will override the simple value
-        /// (<see cref="TopLeftRadius"/>).
-        /// </summary>
-        public Dimension2 TopLeftEllipse
-        {
-            get => _topLeftEllipse;
-            set
-            {
-                _topLeftEllipse = value;
-                if (value != Dimension2.Unset)
-                {
-                    _topLeftRadius = Dimension.Unset;
-                }
-            }
-        }
-
-        private Dimension2 _topLeftEllipse = Dimension2.Unset;
-
-        /// <summary>
-        /// The X is the corner's ellipse X axis half-value and the Y is the corner's ellipse Y axis half-value for
-        /// the top-right corner. Default is <see cref="Dimension2.Unset"/> as normally the more simple, circle corners are used.
-        /// Setting this anything other than <see cref="Dimension2.Unset"/> will override the simple value
-        /// (<see cref="TopRightRadius"/>).
-        /// </summary>
-        public Dimension2 TopRightEllipse
-        {
-            get => _topRightEllipse;
-            set
-            {
-                _topRightEllipse = value;
-                if (value != Dimension2.Unset)
-                {
-                    _topRightRadius = Dimension.Unset;
-                }
-            }
-        }
-
-        private Dimension2 _topRightEllipse = Dimension2.Unset;
-
-        /// <summary>
-        /// The X is the corner's ellipse X axis half-value, and the Y is the corner's ellipse Y axis half-value for
-        /// the bottom-left corner. Default is <see cref="Dimension2.Unset"/> as normally the more simple, circle corners are used.
-        /// Setting this anything other than <see cref="Dimension2.Unset"/> will override the simple value
-        /// (<see cref="BottomLeftRadius"/>).
-        /// </summary>
-        public Dimension2 BottomLeftEllipse
-        {
-            get => _bottomLeftEllipse;
-            set
-            {
-                _bottomLeftEllipse = value;
-                if (value != Dimension2.Unset)
-                {
-                    _bottomLeftRadius = Dimension.Unset;
-                }
-            }
-        }
-
-        private Dimension2 _bottomLeftEllipse = Dimension2.Unset;
-
-        /// <summary>
-        /// The X is the corner's ellipse X axis half-value, and the Y is the corner's ellipse Y axis half-value for
-        /// the bottom-right corner. Default is <see cref="Dimension2.Unset"/> as normally the more simple, circle corners are used.
-        /// Setting this anything other than <see cref="Dimension2.Unset"/> will override the simple value
-        /// (<see cref="BottomRightRadius"/>).
-        /// </summary>
-        public Dimension2 BottomRightEllipse
-        {
-            get => _bottomRightEllipse;
-            set
-            {
-                _bottomRightEllipse = value;
-                if (value != Dimension2.Unset)
-                {
-                    _bottomRightRadius = Dimension.Unset;
-                }
-            }
-        }
-
-        private Dimension2 _bottomRightEllipse = Dimension2.Unset;
+        public CornerInset RoundCornersDescriptor { get; set; } = new();
 
         public RoundedRectangleClipShape() { }
 
@@ -184,10 +187,11 @@ namespace CatUI.Data.Shapes
             Dimension bottomLeft,
             Dimension bottomRight)
         {
-            TopLeftRadius = topLeft;
-            TopRightRadius = topRight;
-            BottomLeftRadius = bottomLeft;
-            BottomRightRadius = bottomRight;
+            RoundCornersDescriptor = new CornerInset(topLeft, topRight, bottomLeft, bottomRight);
+            // TopLeftRadius = topLeft;
+            // TopRightRadius = topRight;
+            // BottomLeftRadius = bottomLeft;
+            // BottomRightRadius = bottomRight;
         }
 
         /// <summary>
@@ -196,10 +200,11 @@ namespace CatUI.Data.Shapes
         /// <param name="cornerRadius">The radius for all corners.</param>
         public RoundedRectangleClipShape(Dimension cornerRadius)
         {
-            TopLeftRadius = cornerRadius;
-            TopRightRadius = cornerRadius;
-            BottomLeftRadius = cornerRadius;
-            BottomRightRadius = cornerRadius;
+            RoundCornersDescriptor = new CornerInset(cornerRadius);
+            // TopLeftRadius = cornerRadius;
+            // TopRightRadius = cornerRadius;
+            // BottomLeftRadius = cornerRadius;
+            // BottomRightRadius = cornerRadius;
         }
 
         /// <summary>
@@ -215,10 +220,8 @@ namespace CatUI.Data.Shapes
             Dimension2 bottomLeftEllipse,
             Dimension2 bottomRightEllipse)
         {
-            TopLeftEllipse = topLeftEllipse;
-            TopRightEllipse = topRightEllipse;
-            BottomLeftEllipse = bottomLeftEllipse;
-            BottomRightEllipse = bottomRightEllipse;
+            RoundCornersDescriptor =
+                new CornerInset(topLeftEllipse, topRightEllipse, bottomRightEllipse, bottomLeftEllipse);
         }
 
         /// <summary>
@@ -227,10 +230,11 @@ namespace CatUI.Data.Shapes
         /// <param name="ellipticalCornerRadius">The radius for all corners.</param>
         public RoundedRectangleClipShape(Dimension2 ellipticalCornerRadius)
         {
-            TopLeftEllipse = ellipticalCornerRadius;
-            TopRightEllipse = ellipticalCornerRadius;
-            BottomLeftEllipse = ellipticalCornerRadius;
-            BottomRightEllipse = ellipticalCornerRadius;
+            RoundCornersDescriptor = new CornerInset(ellipticalCornerRadius);
+            // TopLeftEllipse = ellipticalCornerRadius;
+            // TopRightEllipse = ellipticalCornerRadius;
+            // BottomLeftEllipse = ellipticalCornerRadius;
+            // BottomRightEllipse = ellipticalCornerRadius;
         }
 
         /// <inheritdoc cref="ClipShape.IsPointInside"/>
@@ -264,21 +268,40 @@ namespace CatUI.Data.Shapes
                 switch (i)
                 {
                     case 0:
-                        isElliptical = TopLeftRadius.IsUnset();
-                        width = GetSmallWidth(TopLeftRadius, TopLeftEllipse, bounds, contentScale, viewportSize);
+                        isElliptical = RoundCornersDescriptor.TopLeftRadius.IsUnset();
+                        width = GetSmallWidth(
+                            RoundCornersDescriptor.TopLeftRadius,
+                            RoundCornersDescriptor.TopLeftEllipse,
+                            bounds,
+                            contentScale,
+                            viewportSize);
                         break;
                     case 1:
-                        isElliptical = TopRightRadius.IsUnset();
-                        width = GetSmallWidth(TopRightRadius, TopRightEllipse, bounds, contentScale, viewportSize);
+                        isElliptical = RoundCornersDescriptor.TopRightRadius.IsUnset();
+                        width = GetSmallWidth(
+                            RoundCornersDescriptor.TopRightRadius,
+                            RoundCornersDescriptor.TopRightEllipse,
+                            bounds,
+                            contentScale,
+                            viewportSize);
                         break;
                     case 2:
-                        isElliptical = BottomRightRadius.IsUnset();
-                        width = GetSmallWidth(BottomRightRadius, BottomRightEllipse, bounds, contentScale,
+                        isElliptical = RoundCornersDescriptor.BottomRightRadius.IsUnset();
+                        width = GetSmallWidth(
+                            RoundCornersDescriptor.BottomRightRadius,
+                            RoundCornersDescriptor.BottomRightEllipse,
+                            bounds,
+                            contentScale,
                             viewportSize);
                         break;
                     case 3:
-                        isElliptical = BottomLeftRadius.IsUnset();
-                        width = GetSmallWidth(BottomLeftRadius, BottomLeftEllipse, bounds, contentScale, viewportSize);
+                        isElliptical = RoundCornersDescriptor.BottomLeftRadius.IsUnset();
+                        width = GetSmallWidth(
+                            RoundCornersDescriptor.BottomLeftRadius,
+                            RoundCornersDescriptor.BottomLeftEllipse,
+                            bounds,
+                            contentScale,
+                            viewportSize);
                         break;
                 }
 
@@ -288,17 +311,35 @@ namespace CatUI.Data.Shapes
                 switch (i)
                 {
                     case 0:
-                        height = GetSmallHeight(TopLeftRadius, TopLeftEllipse, bounds, contentScale, viewportSize);
+                        height = GetSmallHeight(
+                            RoundCornersDescriptor.TopLeftRadius,
+                            RoundCornersDescriptor.TopLeftEllipse,
+                            bounds,
+                            contentScale,
+                            viewportSize);
                         break;
                     case 1:
-                        height = GetSmallHeight(TopRightRadius, TopRightEllipse, bounds, contentScale, viewportSize);
+                        height = GetSmallHeight(
+                            RoundCornersDescriptor.TopRightRadius,
+                            RoundCornersDescriptor.TopRightEllipse,
+                            bounds,
+                            contentScale,
+                            viewportSize);
                         break;
                     case 2:
-                        height = GetSmallHeight(BottomRightRadius, BottomRightEllipse, bounds, contentScale,
+                        height = GetSmallHeight(
+                            RoundCornersDescriptor.BottomRightRadius,
+                            RoundCornersDescriptor.BottomRightEllipse,
+                            bounds,
+                            contentScale,
                             viewportSize);
                         break;
                     case 3:
-                        height = GetSmallHeight(BottomLeftRadius, BottomLeftEllipse, bounds, contentScale,
+                        height = GetSmallHeight(
+                            RoundCornersDescriptor.BottomLeftRadius,
+                            RoundCornersDescriptor.BottomLeftEllipse,
+                            bounds,
+                            contentScale,
                             viewportSize);
                         break;
                 }
@@ -381,34 +422,50 @@ namespace CatUI.Data.Shapes
             roundRect.SetRectRadii(
                 bounds,
                 [
-                    TopLeftRadius.IsUnset()
+                    RoundCornersDescriptor.TopLeftRadius.IsUnset()
                         ? new SKPoint(
-                            TopLeftEllipse.X.CalculateDimension(bounds.Width, contentScale, viewportSize),
-                            TopLeftEllipse.Y.CalculateDimension(bounds.Width, contentScale, viewportSize))
+                            RoundCornersDescriptor.TopLeftEllipse.X.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize),
+                            RoundCornersDescriptor.TopLeftEllipse.Y.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize))
                         : new SKPoint(
-                            TopLeftRadius.CalculateDimension(bounds.Width, contentScale, viewportSize),
-                            TopLeftRadius.CalculateDimension(bounds.Width, contentScale, viewportSize)),
-                    TopRightRadius.IsUnset()
+                            RoundCornersDescriptor.TopLeftRadius.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize),
+                            RoundCornersDescriptor.TopLeftRadius.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize)),
+                    RoundCornersDescriptor.TopRightRadius.IsUnset()
                         ? new SKPoint(
-                            TopRightEllipse.X.CalculateDimension(bounds.Width, contentScale, viewportSize),
-                            TopRightEllipse.Y.CalculateDimension(bounds.Width, contentScale, viewportSize))
+                            RoundCornersDescriptor.TopRightEllipse.X.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize),
+                            RoundCornersDescriptor.TopRightEllipse.Y.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize))
                         : new SKPoint(
-                            TopRightRadius.CalculateDimension(bounds.Width, contentScale, viewportSize),
-                            TopRightRadius.CalculateDimension(bounds.Width, contentScale, viewportSize)),
-                    BottomRightRadius.IsUnset()
+                            RoundCornersDescriptor.TopRightRadius.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize),
+                            RoundCornersDescriptor.TopRightRadius.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize)),
+                    RoundCornersDescriptor.BottomRightRadius.IsUnset()
                         ? new SKPoint(
-                            BottomRightEllipse.X.CalculateDimension(bounds.Width, contentScale, viewportSize),
-                            BottomRightEllipse.Y.CalculateDimension(bounds.Width, contentScale, viewportSize))
+                            RoundCornersDescriptor.BottomRightEllipse.X.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize),
+                            RoundCornersDescriptor.BottomRightEllipse.Y.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize))
                         : new SKPoint(
-                            BottomRightRadius.CalculateDimension(bounds.Width, contentScale, viewportSize),
-                            BottomRightRadius.CalculateDimension(bounds.Width, contentScale, viewportSize)),
-                    BottomLeftRadius.IsUnset()
+                            RoundCornersDescriptor.BottomRightRadius.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize),
+                            RoundCornersDescriptor.BottomRightRadius.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize)),
+                    RoundCornersDescriptor.BottomLeftRadius.IsUnset()
                         ? new SKPoint(
-                            BottomLeftEllipse.X.CalculateDimension(bounds.Width, contentScale, viewportSize),
-                            BottomLeftEllipse.Y.CalculateDimension(bounds.Width, contentScale, viewportSize))
+                            RoundCornersDescriptor.BottomLeftEllipse.X.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize),
+                            RoundCornersDescriptor.BottomLeftEllipse.Y.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize))
                         : new SKPoint(
-                            BottomLeftRadius.CalculateDimension(bounds.Width, contentScale, viewportSize),
-                            BottomLeftRadius.CalculateDimension(bounds.Width, contentScale, viewportSize))
+                            RoundCornersDescriptor.BottomLeftRadius.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize),
+                            RoundCornersDescriptor.BottomLeftRadius.CalculateDimension(
+                                bounds.Width, contentScale, viewportSize))
                 ]);
 
             SKPath path = new();
@@ -497,17 +554,7 @@ namespace CatUI.Data.Shapes
 
         public override RoundedRectangleClipShape Duplicate()
         {
-            return new RoundedRectangleClipShape
-            {
-                TopLeftEllipse = TopLeftEllipse,
-                TopRightEllipse = TopRightEllipse,
-                BottomLeftEllipse = BottomLeftEllipse,
-                BottomRightEllipse = BottomRightEllipse,
-                TopLeftRadius = TopLeftRadius,
-                TopRightRadius = TopRightRadius,
-                BottomLeftRadius = BottomLeftRadius,
-                BottomRightRadius = BottomRightRadius
-            };
+            return new RoundedRectangleClipShape { RoundCornersDescriptor = RoundCornersDescriptor.Duplicate() };
         }
     }
 }

--- a/src/CatUI.Data/Theming/ClipShapes/CatThemeClipShapes.cs
+++ b/src/CatUI.Data/Theming/ClipShapes/CatThemeClipShapes.cs
@@ -164,7 +164,7 @@ namespace CatUI.Data.Theming.ClipShapes
             RoundedRectangleClipShape originalShape,
             AsymmetryDirection direction)
         {
-            Dimension radius = originalShape.TopLeftRadius;
+            Dimension radius = originalShape.RoundCornersDescriptor.TopLeftRadius;
 
             switch (direction)
             {

--- a/src/CatUI.Elements/Shapes/AbstractShapeElement.cs
+++ b/src/CatUI.Elements/Shapes/AbstractShapeElement.cs
@@ -1,5 +1,6 @@
 using CatUI.Data;
 using CatUI.Data.Brushes;
+using CatUI.Data.Shapes;
 
 namespace CatUI.Elements.Shapes
 {
@@ -9,6 +10,12 @@ namespace CatUI.Elements.Shapes
     /// </summary>
     public abstract class AbstractShapeElement : Element
     {
+        /// <summary>
+        /// Will return the clip shape that has the same properties of this shape.
+        /// </summary>
+        /// <returns></returns>
+        public abstract ClipShape CorrespondingClipShape { get; }
+
         /// <summary>
         /// The "brush" used to fill the shape. A brush contains information like the color to use, if it can use an image
         /// as fill etc. The default value is a <see cref="ColorBrush"/> that has a completely transparent color,

--- a/src/CatUI.Elements/Shapes/EllipseElement.cs
+++ b/src/CatUI.Elements/Shapes/EllipseElement.cs
@@ -31,9 +31,12 @@ namespace CatUI.Elements.Shapes
 
         private ObjectRef<EllipseElement>? _ref;
 
+        public override ClipShape CorrespondingClipShape { get; }
+
         public EllipseElement(IBrush? fillBrush = null, IBrush? outlineBrush = null)
             : base(fillBrush, outlineBrush)
         {
+            CorrespondingClipShape = new EllipseClipShape();
         }
 
         /// <summary>
@@ -60,6 +63,7 @@ namespace CatUI.Elements.Shapes
 
             Position = new Dimension2(centerPoint.X - radiusX, centerPoint.Y - radiusY);
             Layout = new ElementLayout().SetFixedWidth(radiusX * 2f).SetFixedHeight(radiusY * 2f);
+            CorrespondingClipShape = new EllipseClipShape();
         }
 
         protected override void DrawBackground()

--- a/src/CatUI.Elements/Shapes/GeometricPathElement.cs
+++ b/src/CatUI.Elements/Shapes/GeometricPathElement.cs
@@ -48,6 +48,10 @@ namespace CatUI.Elements.Shapes
 
         private ObjectRef<GeometricPathElement>? _ref;
 
+        public override ClipShape CorrespondingClipShape => _clipShape;
+
+        private readonly ClipShape _clipShape;
+
         private SKPath _skiaPath = new();
 
         /// <summary>
@@ -73,6 +77,11 @@ namespace CatUI.Elements.Shapes
         private void SetShouldApplyScaling(bool value)
         {
             _shouldApplyScaling = value;
+            if (_clipShape is PathClipShape pathClipShape)
+            {
+                pathClipShape.ShouldApplyScaling = value;
+            }
+
             SetLocalValue(nameof(ShouldApplyScaling), value);
             MarkLayoutDirty();
         }
@@ -119,6 +128,11 @@ namespace CatUI.Elements.Shapes
                 PathCache.CacheNewPath(_skiaPath);
             }
 
+            if (_clipShape is PathClipShape pathClipShape)
+            {
+                pathClipShape.SvgPath = _svgPath;
+            }
+
             SetLocalValue(nameof(SvgPath), value);
             MarkLayoutDirty();
         }
@@ -130,6 +144,7 @@ namespace CatUI.Elements.Shapes
             SvgPathProperty.ValueChangedEvent += SetSvgPath;
 
             SvgPath = svgPath;
+            _clipShape = new PathClipShape();
         }
 
         //~GeometricPathElement()
@@ -160,6 +175,11 @@ namespace CatUI.Elements.Shapes
             PathCache.RemovePath(_skiaPath);
             _skiaPath = path;
             PathCache.CacheNewPath(_skiaPath);
+
+            if (_clipShape is PathClipShape pathClipShape)
+            {
+                pathClipShape.SetNewSkiaPath(path);
+            }
         }
 
         /// <summary>
@@ -171,6 +191,11 @@ namespace CatUI.Elements.Shapes
             PathCache.RemovePath(_skiaPath);
             _skiaPath = SKPath.ParseSvgPathData(svgPath);
             PathCache.CacheNewPath(_skiaPath);
+
+            if (_clipShape is PathClipShape pathClipShape)
+            {
+                pathClipShape.SvgPath = svgPath;
+            }
         }
 
         protected override void DrawBackground()

--- a/src/CatUI.Elements/Shapes/RectangleElement.cs
+++ b/src/CatUI.Elements/Shapes/RectangleElement.cs
@@ -31,9 +31,12 @@ namespace CatUI.Elements.Shapes
 
         private ObjectRef<RectangleElement>? _ref;
 
+        public override ClipShape CorrespondingClipShape { get; }
+
         public RectangleElement(IBrush? fillBrush = null, IBrush? outlineBrush = null)
             : base(fillBrush, outlineBrush)
         {
+            CorrespondingClipShape = new RectangleClipShape();
         }
 
         /// <summary>
@@ -55,6 +58,8 @@ namespace CatUI.Elements.Shapes
                 new ElementLayout()
                     .SetFixedWidth(Math.Abs(rectDescriptor.Width))
                     .SetFixedHeight(Math.Abs(rectDescriptor.Height));
+
+            CorrespondingClipShape = new RectangleClipShape();
         }
 
         protected override void DrawBackground()

--- a/src/CatUI.Elements/Shapes/RoundedRectangleElement.cs
+++ b/src/CatUI.Elements/Shapes/RoundedRectangleElement.cs
@@ -1,0 +1,145 @@
+using System;
+using CatUI.Data;
+using CatUI.Data.Brushes;
+using CatUI.Data.Containers;
+using CatUI.Data.ElementData;
+using CatUI.Data.Shapes;
+using CatUI.RenderingEngine;
+using CatUI.Utils;
+using SkiaSharp;
+
+namespace CatUI.Elements.Shapes
+{
+    public class RoundedRectangleElement : AbstractShapeElement
+    {
+        /// <inheritdoc cref="Element.Ref"/>
+        public new ObjectRef<RoundedRectangleElement>? Ref
+        {
+            get => _ref;
+            set
+            {
+                _ref = value;
+                if (_ref != null)
+                {
+                    _ref.Value = this;
+                }
+            }
+        }
+
+        private ObjectRef<RoundedRectangleElement>? _ref;
+
+        public override ClipShape CorrespondingClipShape => _clipShape;
+
+        private readonly ClipShape _clipShape;
+
+        public CornerInset RoundCornersDescriptor
+        {
+            get => _roundCornersDescriptor;
+            set => SetRoundCornersDescriptor(value);
+        }
+
+        private CornerInset _roundCornersDescriptor = new();
+        public ObservableProperty<CornerInset> RoundCornersDescriptorProperty { get; } = new(new CornerInset());
+
+        private void SetRoundCornersDescriptor(CornerInset? value)
+        {
+            if (value != null)
+            {
+                _roundCornersDescriptor = value;
+                if (_clipShape is RoundedRectangleClipShape clipShape)
+                {
+                    clipShape.RoundCornersDescriptor = _roundCornersDescriptor;
+                }
+
+                RequestRedraw();
+            }
+        }
+
+        public RoundedRectangleElement(IBrush? fillBrush = null, IBrush? outlineBrush = null)
+            : base(fillBrush, outlineBrush)
+        {
+            RoundCornersDescriptorProperty.ValueChangedEvent += SetRoundCornersDescriptor;
+            _clipShape = new RoundedRectangleClipShape();
+        }
+
+        /// <summary>
+        /// Constructs a rounded rectangle given a Rect descriptor that has the X, Y, Width, and Height, but not the corner
+        /// radii (those need to be set separately using the available properties).
+        /// </summary>
+        /// <param name="rectDescriptor"></param>
+        /// <param name="fillBrush"></param>
+        /// <param name="outlineBrush"></param>
+        public RoundedRectangleElement(
+            Rect rectDescriptor,
+            IBrush? fillBrush = null,
+            IBrush? outlineBrush = null)
+            : base(fillBrush, outlineBrush)
+        {
+            RoundCornersDescriptorProperty.ValueChangedEvent += SetRoundCornersDescriptor;
+            _clipShape = new RoundedRectangleClipShape();
+
+            Position = new Dimension2(rectDescriptor.X, rectDescriptor.Y);
+            Layout =
+                new ElementLayout()
+                    .SetFixedWidth(Math.Abs(rectDescriptor.Width))
+                    .SetFixedHeight(Math.Abs(rectDescriptor.Height));
+        }
+
+        protected override void DrawBackground()
+        {
+            if (!IsCurrentlyVisible)
+            {
+                return;
+            }
+
+            Renderer? renderer = Document?.Renderer;
+            if (renderer == null)
+            {
+                return;
+            }
+
+            SKPath clipPath = _clipShape.GetSkiaClipPath(
+                Bounds,
+                Document?.ContentScale ?? 1f,
+                Document?.ViewportSize ?? new Size());
+
+            int saveCount = renderer.SaveCanvasState();
+            renderer.SetClipPath(clipPath);
+            renderer.DrawRect(Bounds, FillBrush, RoundCornersDescriptor);
+
+            if (OutlineBrush.IsSkippable || OutlineParameters.OutlineWidth == 0)
+            {
+                renderer.RestoreCanvasState(saveCount);
+                return;
+            }
+
+            Document?.Renderer.DrawRectOutline(Bounds, OutlineBrush, OutlineParameters, RoundCornersDescriptor);
+            renderer.RestoreCanvasState(saveCount);
+        }
+
+        public override RoundedRectangleElement Duplicate()
+        {
+            RoundedRectangleElement el = new()
+            {
+                RoundCornersDescriptor = RoundCornersDescriptor.Duplicate(),
+                //AbstractShapeElement
+                FillBrush = FillBrush.Duplicate(),
+                OutlineBrush = OutlineBrush.Duplicate(),
+                OutlineParameters = OutlineParameters,
+                //
+                State = State,
+                Position = Position,
+                Background = Background.Duplicate(),
+                ClipPath = (ClipShape?)ClipPath?.Duplicate(),
+                ClipType = ClipType,
+                LocallyVisible = LocallyVisible,
+                LocallyEnabled = LocallyEnabled,
+                ElementContainerSizing = (ContainerSizing?)ElementContainerSizing?.Duplicate(),
+                Layout = Layout
+            };
+
+            DuplicateChildrenUtil(el);
+            return el;
+        }
+    }
+}

--- a/src/CatUI.RenderingEngine/ShapeRendererPartial.cs
+++ b/src/CatUI.RenderingEngine/ShapeRendererPartial.cs
@@ -169,16 +169,16 @@ namespace CatUI.RenderingEngine
             {
                 if (roundedCorners.TopRightRadius.IsUnset())
                 {
-                    radii[0] = new SKPoint(0, 0);
+                    radii[1] = new SKPoint(0, 0);
                 }
                 else
                 {
-                    radii[0] = new SKPoint(roundedCorners.TopRightRadius.Value, roundedCorners.TopRightRadius.Value);
+                    radii[1] = new SKPoint(roundedCorners.TopRightRadius.Value, roundedCorners.TopRightRadius.Value);
                 }
             }
             else
             {
-                radii[0] =
+                radii[1] =
                     new SKPoint(
                         roundedCorners.TopRightEllipse.X.Value,
                         roundedCorners.TopRightEllipse.Y.Value);
@@ -188,17 +188,17 @@ namespace CatUI.RenderingEngine
             {
                 if (roundedCorners.BottomRightRadius.IsUnset())
                 {
-                    radii[0] = new SKPoint(0, 0);
+                    radii[2] = new SKPoint(0, 0);
                 }
                 else
                 {
-                    radii[0] = new SKPoint(roundedCorners.BottomRightRadius.Value,
+                    radii[2] = new SKPoint(roundedCorners.BottomRightRadius.Value,
                         roundedCorners.BottomRightRadius.Value);
                 }
             }
             else
             {
-                radii[0] =
+                radii[2] =
                     new SKPoint(
                         roundedCorners.BottomRightEllipse.X.Value,
                         roundedCorners.BottomRightEllipse.Y.Value);
@@ -208,17 +208,17 @@ namespace CatUI.RenderingEngine
             {
                 if (roundedCorners.BottomLeftRadius.IsUnset())
                 {
-                    radii[0] = new SKPoint(0, 0);
+                    radii[3] = new SKPoint(0, 0);
                 }
                 else
                 {
-                    radii[0] = new SKPoint(roundedCorners.BottomLeftRadius.Value,
+                    radii[3] = new SKPoint(roundedCorners.BottomLeftRadius.Value,
                         roundedCorners.BottomLeftRadius.Value);
                 }
             }
             else
             {
-                radii[0] =
+                radii[3] =
                     new SKPoint(
                         roundedCorners.BottomLeftEllipse.X.Value,
                         roundedCorners.BottomLeftEllipse.Y.Value);


### PR DESCRIPTION
- `AbstractShapeElement`s now return the clip shape that is identical to themselves.
- Fix a bug affecting drawing rounded rectangles in the renderer.
- Refactor RoundedRectangleClipShape to use CornerInset instead of custom properties.